### PR TITLE
📬 Improve attribute parsing and parse sender report packets

### DIFF
--- a/AudioCodec.h
+++ b/AudioCodec.h
@@ -1,0 +1,39 @@
+/**
+ * @file VideoCodec.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @version 0.1
+ * @date 2020-08-24
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#pragma once
+#include <algorithm>
+#include <string>
+
+enum class AudioCodecKind
+{
+    Unsupported = 0,
+    Opus
+};
+
+class SupportedAudioCodecs
+{
+public:
+    static AudioCodecKind ParseAudioCodec(const std::string codec)
+    {
+        std::string lowercaseCodec = codec;
+        std::transform(
+            lowercaseCodec.begin(),
+            lowercaseCodec.end(),
+            lowercaseCodec.begin(),
+            [](unsigned char c){ return std::tolower(c); });
+
+        if (lowercaseCodec.compare("opus") == 0)
+        {
+            return AudioCodecKind::Opus;
+        }
+        return AudioCodecKind::Unsupported;
+    }
+};

--- a/FtlStream.cpp
+++ b/FtlStream.cpp
@@ -14,6 +14,7 @@
 extern "C"
 {
     #include <debug.h>
+    #include <sys/time.h>
 }
 
 #pragma region Constructor/Destructor
@@ -167,9 +168,10 @@ void FtlStream::startStreamThread()
                 (struct sockaddr*)&remote,
                 &addrlen);
 
-            if (bytesRead < 0 || !janus_is_rtp(buffer, bytesRead))
+            if (bytesRead < 12)
             {
-                // We don't care about non-RTP packets
+                // This packet is too small to have an RTP header.
+                JANUS_LOG(LOG_WARN, "FTL: Received non-RTP packet.");
                 continue;
             }
 
@@ -188,7 +190,6 @@ void FtlStream::startStreamThread()
             // FTL designates payload type 96 as video (H264 or VP8)
             else if (rtpHeader->type == 96)
             {
-                
                 relayRtpPacket({
                     .rtpHeader = rtpHeader,
                     .rtpHeaderLength = static_cast<uint16_t>(bytesRead),
@@ -197,7 +198,27 @@ void FtlStream::startStreamThread()
             }
             else
             {
-                JANUS_LOG(LOG_INFO, "FTL: Unknown RTP payload type %d", rtpHeader->type);
+                // FTL implementation uses the marker bit space for payload types above 127
+                // when the payload type is not audio or video. So we need to reconstruct it.
+                uint8_t payloadType = 
+                    ((static_cast<uint8_t>(rtpHeader->markerbit) << 7) | static_cast<uint8_t>(rtpHeader->type));
+                
+                if (payloadType == FTL_PAYLOAD_TYPE_PING)
+                {
+                    handlePing(rtpHeader, bytesRead);
+                }
+                else if (payloadType == FTL_PAYLOAD_TYPE_SENDER_REPORT)
+                {
+                    handleSenderReport(rtpHeader, bytesRead);
+                }
+                else
+                {
+                    JANUS_LOG(
+                        LOG_WARN,
+                        "FTL: Unknown RTP payload type %d (orig %d)\n",
+                        payloadType,
+                        rtpHeader->type);
+                }
             }
         }
     }
@@ -216,5 +237,36 @@ void FtlStream::relayRtpPacket(RtpRelayPacket rtpPacket)
     {
         session->RelayRtpPacket(rtpPacket);
     }
+}
+
+void FtlStream::handlePing(janus_rtp_header* rtpHeader, uint16_t length)
+{
+    // These pings are useless - FTL tries to determine 'ping' by having a timestamp
+    // sent across and compared against the remote's clock. This assumes that there is
+    // no time difference between the client and server, which is practically never true.
+
+    // We'll just ignore these pings, since they wouldn't give us any useful information
+    // anyway.
+}
+
+void FtlStream::handleSenderReport(janus_rtp_header* rtpHeader, uint16_t length)
+{
+    // We expect this packet to be 28 bytes big.
+    if (length != 28)
+    {
+        JANUS_LOG(LOG_WARN, "Invalid sender report packet of length %d (expect 28)\n", length);
+    }
+    char* packet = reinterpret_cast<char*>(rtpHeader);
+    uint32_t ssrc              = ntohl(*reinterpret_cast<uint32_t*>(packet + 4));
+    uint32_t ntpTimestampHigh  = ntohl(*reinterpret_cast<uint32_t*>(packet + 8));
+    uint32_t ntpTimestampLow   = ntohl(*reinterpret_cast<uint32_t*>(packet + 12));
+    uint32_t rtpTimestamp      = ntohl(*reinterpret_cast<uint32_t*>(packet + 16));
+    uint32_t senderPacketCount = ntohl(*reinterpret_cast<uint32_t*>(packet + 20));
+    uint32_t senderOctetCount  = ntohl(*reinterpret_cast<uint32_t*>(packet + 24));
+
+    uint64_t ntpTimestamp = (static_cast<uint64_t>(ntpTimestampHigh) << 32) | 
+        static_cast<uint64_t>(ntpTimestampLow);
+
+    //JANUS_LOG(LOG_INFO, "FTL: Sender report:\n\tssrc:     %u\n\trtp time: %u\n\tntp time: %lu\n\tpkt cnt:   %u\n\toct cnt:  %u\n", ssrc, rtpTimestamp, ntpTimestamp, senderPacketCount, senderOctetCount);
 }
 #pragma endregion

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -56,6 +56,8 @@ private:
     /* Private members */
     const std::shared_ptr<IngestConnection> ingestConnection;
     const uint16_t mediaPort; // Port that this stream is listening on
+    const uint8_t audioPayloadType = 0;
+    const uint8_t videoPayloadType = 0;
     janus_rtp_switching_context rtpSwitchingContext;
     int mediaSocketHandle;
     std::thread streamThread;

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -47,6 +47,12 @@ public:
     std::list<std::shared_ptr<JanusSession>> GetViewers();
 
 private:
+    /* Constants */
+    static constexpr uint64_t MICROSECONDS_PER_SECOND        = 1000000;
+    static constexpr float    MICROSECONDS_PER_MILLISECOND   = 1000.0f;
+    static constexpr uint8_t  FTL_PAYLOAD_TYPE_SENDER_REPORT = 200;
+    static constexpr uint8_t  FTL_PAYLOAD_TYPE_PING          = 250;
+
     /* Private members */
     const std::shared_ptr<IngestConnection> ingestConnection;
     const uint16_t mediaPort; // Port that this stream is listening on
@@ -62,4 +68,6 @@ private:
     void ingestConnectionClosed(IngestConnection& connection);
     void startStreamThread();
     void relayRtpPacket(RtpRelayPacket rtpPacket);
+    void handlePing(janus_rtp_header* rtpHeader, uint16_t length);
+    void handleSenderReport(janus_rtp_header* rtpHeader, uint16_t length);
 };

--- a/IngestConnection.h
+++ b/IngestConnection.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include "CredStore.h"
+#include "AudioCodec.h"
+#include "VideoCodec.h"
 
 #include <thread>
 #include <random>
@@ -45,21 +47,43 @@ public:
     void Stop();
     // Getters/Setters
     uint32_t GetChannelId();
+    bool GetHasVideo();
+    bool GetHasAudio();
+    VideoCodecKind GetVideoCodec();
+    AudioCodecKind GetAudioCodec();
+    uint32_t GetAudioSsrc();
+    uint32_t GetVideoSsrc();
+    uint8_t GetAudioPayloadType();
+    uint8_t GetVideoPayloadType();
     // Callbacks
     void SetOnClosed(std::function<void (IngestConnection&)> callback);
     void SetOnRequestMediaConnection(std::function<uint16_t (IngestConnection&)> callback);
 
 private:
+    /* Private static members */
+    static const std::array<char, 4> commandDelimiter;
     /* Private members */
     bool isAuthenticated = false;
+    bool isStreaming = false;
     uint32_t channelId = 0;
     int connectionHandle;
     std::shared_ptr<CredStore> credStore;
     std::thread connectionThread;
-    const std::array<char, 4> commandDelimiter = { '\r', '\n', '\r', '\n' };
     std::array<uint8_t, 128> hmacPayload;
     std::default_random_engine randomEngine { std::random_device()() };
-    std::map<std::string, std::string> attributes;
+    // Stream metadata
+    std::string vendorName;
+    std::string vendorVersion;
+    bool hasVideo = false;
+    bool hasAudio = false;
+    VideoCodecKind videoCodec;
+    AudioCodecKind audioCodec;
+    uint16_t videoWidth;
+    uint16_t videoHeight;
+    uint32_t audioSsrc = 0;
+    uint32_t videoSsrc = 0;
+    uint8_t audioPayloadType = 0;
+    uint8_t videoPayloadType = 0;
     // Regex patterns
     std::regex connectPattern = std::regex(R"~(CONNECT ([0-9]+) \$([0-9a-f]+))~");
     std::regex attributePattern = std::regex(R"~((.+): (.+))~");

--- a/JanusFtl.cpp
+++ b/JanusFtl.cpp
@@ -362,9 +362,10 @@ std::string JanusFtl::generateSdpOffer(
         "m=video 1 RTP/SAVPF 96\r\n" <<
         "c=IN IP4 1.1.1.1\r\n" <<
         "a=rtpmap:96 H264/90000\r\n" <<       // TODO: We only support H264 right now.
-        "a=rtcp-fb:96 nack\r\n" <<            // Send us NACK's
-        "a=rtcp-fb:96 nack pli\r\n" <<        // Send us picture-loss-indicators
-        "a=rtcp-fb:96 nack goog-remb\r\n" <<  // Send some congestion indicator thing
+        "a=fmtp:96 profile-level-id=42e01f;packetization-mode=0;"
+        //"a=rtcp-fb:96 nack\r\n" <<            // Send us NACK's
+        //"a=rtcp-fb:96 nack pli\r\n" <<        // Send us picture-loss-indicators
+        //"a=rtcp-fb:96 nack goog-remb\r\n" <<  // Send some congestion indicator thing
         "a=sendonly\r\n" <<
         "a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid\r\n";
 

--- a/VideoCodec.h
+++ b/VideoCodec.h
@@ -1,0 +1,39 @@
+/**
+ * @file VideoCodec.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @version 0.1
+ * @date 2020-08-24
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#pragma once
+#include <algorithm>
+#include <string>
+
+enum class VideoCodecKind
+{
+    Unsupported = 0,
+    H264
+};
+
+class SupportedVideoCodecs
+{
+public:
+    static VideoCodecKind ParseVideoCodec(const std::string codec)
+    {
+        std::string lowercaseCodec = codec;
+        std::transform(
+            lowercaseCodec.begin(),
+            lowercaseCodec.end(),
+            lowercaseCodec.begin(),
+            [](unsigned char c){ return std::tolower(c); });
+
+        if (lowercaseCodec.compare("h264") == 0)
+        {
+            return VideoCodecKind::H264;
+        }
+        return VideoCodecKind::Unsupported;
+    }
+};


### PR DESCRIPTION
This change makes some small improvements to attribute parsing during ingest. Audio/video codec, ssrc, payload type, etc. are actually parsed and communicated to the `FtlStream` to process against incoming media packets instead of hard-coded values. Some rudimentary validation is also performed when the client attempts to begin streaming.

A change was also made to the SDP payload to resolve an issue with Firefox failing to decode the video stream.