### PR TITLE
👀 Handle pending sessions gracefully

### DIFF
--- a/AudioCodec.h
+++ b/AudioCodec.h
@@ -36,4 +36,16 @@ public:
         }
         return AudioCodecKind::Unsupported;
     }
+
+    static std::string AudioCodecString(const AudioCodecKind codec)
+    {
+        switch (codec)
+        {
+        case AudioCodecKind::Opus:
+            return "opus";
+        case AudioCodecKind::Unsupported:
+        default:
+            return "";
+        }
+    }
 };

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -44,6 +44,14 @@ public:
     /* Getters/Setters */
     uint64_t GetChannelId();
     uint16_t GetMediaPort();
+    bool GetHasVideo();
+    bool GetHasAudio();
+    VideoCodecKind GetVideoCodec();
+    AudioCodecKind GetAudioCodec();
+    uint32_t GetAudioSsrc();
+    uint32_t GetVideoSsrc();
+    uint8_t GetAudioPayloadType();
+    uint8_t GetVideoPayloadType();
     std::list<std::shared_ptr<JanusSession>> GetViewers();
 
 private:
@@ -56,8 +64,6 @@ private:
     /* Private members */
     const std::shared_ptr<IngestConnection> ingestConnection;
     const uint16_t mediaPort; // Port that this stream is listening on
-    const uint8_t audioPayloadType = 0;
-    const uint8_t videoPayloadType = 0;
     janus_rtp_switching_context rtpSwitchingContext;
     int mediaSocketHandle;
     std::thread streamThread;

--- a/FtlStreamStore.h
+++ b/FtlStreamStore.h
@@ -15,23 +15,102 @@
 
 #include <memory>
 #include <map>
+#include <set>
 #include <mutex>
 
 /**
- * @brief Handles storage and retrieval of FTL stream instances and their viewer sessions
+ * @brief Handles storage and retrieval of FTL stream instances and associated viewer sessions
  */
 class FtlStreamStore
 {
 public:
-    /* Public methods */
+    /**
+     * @brief Adds the specified FtlStream instance to the stream store.
+     * @param ftlStream The stream to add
+     */
     void AddStream(std::shared_ptr<FtlStream> ftlStream);
+
+    /**
+     * @brief Adds the specified JanusSession as a viewer of the specified FtlStream
+     * @param ftlStream The stream to be viewed
+     * @param session The viewer session
+     */
     void AddViewer(std::shared_ptr<FtlStream> ftlStream, std::shared_ptr<JanusSession> session);
+
+    /**
+     * @brief Returns whether the given FtlStream is present in the stream store.
+     * @param ftlStream The stream to be tested
+     * @return true if stream is present
+     * @return false if stream is not present
+     */
     bool HasStream(std::shared_ptr<FtlStream> ftlStream);
+
+    /**
+     * @brief Get the FtlStream with the given channel id.
+     * @param channelId channel ID to match against FtlStream
+     * @return std::shared_ptr<FtlStream> Matching FtlStream
+     * @return nullptr No matching FtlStream
+     */
     std::shared_ptr<FtlStream> GetStreamByChannelId(uint64_t channelId);
+
+    /**
+     * @brief Get the FtlStream with the given media port assignment.
+     * @param mediaPort media port to match against FtlStream
+     * @return std::shared_ptr<FtlStream> Matching FtlStream
+     * @return nullptr No matching FtlStream
+     */
     std::shared_ptr<FtlStream> GetStreamByMediaPort(uint16_t mediaPort);
+
+    /**
+     * @brief Get the FtlStream currently being viewed by the given session.
+     * @param session session to match against FtlStream viewers
+     * @return std::shared_ptr<FtlStream> Matching FtlStream
+     * @return nullptr No matching FtlStream
+     */
     std::shared_ptr<FtlStream> GetStreamBySession(std::shared_ptr<JanusSession> session);
+
+    /**
+     * @brief Removes the given stream from the stream store.
+     * @param ftlStream The stream to remove
+     */
     void RemoveStream(std::shared_ptr<FtlStream> ftlStream);
+
+    /**
+     * @brief Removes the given session from viewership of an active FtlStream.
+     * @param ftlStream The stream to remove the session from
+     * @param session The session to remove
+     */
     void RemoveViewer(std::shared_ptr<FtlStream> ftlStream, std::shared_ptr<JanusSession> session);
+
+    /**
+     * @brief 
+     *  Adds the given session as a 'pending' viewer for a channel ID that does not currently
+     *  have an active stream.
+     * @param channelId The channel ID the session is pending viewership of
+     * @param session The viewer session
+     */
+    void AddPendingViewerForChannelId(uint16_t channelId, std::shared_ptr<JanusSession> session);
+
+    /**
+     * @brief Get the pending viewer sessions for a given channel ID
+     * 
+     * @param channelId Channel ID to retrieve pending viewers for
+     * @return std::list<std::shared_ptr<JanusSession>> List of pending viewers
+     */
+    std::set<std::shared_ptr<JanusSession>> GetPendingViewersForChannelId(uint16_t channelId);
+
+    /**
+     * @brief Clears pending viewer store for a given channel ID
+     * @param channelId Channel ID to clear pending viewers for
+     * @return std::list<std::shared_ptr<JanusSession>> List of pending viewers that were cleared
+     */
+    std::set<std::shared_ptr<JanusSession>> ClearPendingViewersForChannelId(uint16_t channelId);
+
+    /**
+     * @brief Removes any pending viewership for a given session.
+     * @param session Session to remove from pending viewer stores.
+     */
+    void RemovePendingViewershipForSession(std::shared_ptr<JanusSession> session);
 private:
     /* Private members */
     std::mutex channelIdMapMutex;
@@ -40,4 +119,7 @@ private:
     std::map<uint16_t, std::shared_ptr<FtlStream>> ftlStreamsByMediaPort;
     std::mutex sessionMapMutex;
     std::map<std::shared_ptr<JanusSession>, std::shared_ptr<FtlStream>> ftlStreamsBySession;
+    std::mutex pendingSessionMutex;
+    std::map<uint16_t, std::set<std::shared_ptr<JanusSession>>> pendingChannelIdSessions;
+    std::map<std::shared_ptr<JanusSession>, uint16_t> pendingSessionChannelId;
 };

--- a/JanusFtl.h
+++ b/JanusFtl.h
@@ -84,5 +84,6 @@ private:
     janus_plugin_result* generateMessageErrorResponse(int errorCode, std::string errorMessage);
     janus_plugin_result* handleWatchMessage(std::shared_ptr<JanusSession> session, JsonPtr message, char* transaction);
     janus_plugin_result* handleStartMessage(std::shared_ptr<JanusSession> session, JsonPtr message, char* transaction);
+    int sendJsep(std::shared_ptr<JanusSession> session, std::shared_ptr<FtlStream> ftlStream, char* transaction);
     std::string generateSdpOffer(std::shared_ptr<JanusSession> session, std::shared_ptr<FtlStream> ftlStream);
 };

--- a/VideoCodec.h
+++ b/VideoCodec.h
@@ -36,4 +36,16 @@ public:
         }
         return VideoCodecKind::Unsupported;
     }
+
+    static std::string VideoCodecString(const VideoCodecKind codec)
+    {
+        switch (codec)
+        {
+        case VideoCodecKind::H264:
+            return "H264";
+        case VideoCodecKind::Unsupported:
+        default:
+            return "";
+        }
+    }
 };


### PR DESCRIPTION
This change allows for sessions to complete a watch request for a channel ID that does not yet have a stream started. These sessions will be put into a 'pending' state until a stream is available with the given channel ID.

Sessions that exist when a stream has ended will also be put into this 'pending' state until the session ends or the channel ID starts a new stream.

This change also includes a fix for #5.