### PR TITLE
🧵 Introduce thread pool model for relaying packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 test/test
 core
 build/
+builddir/

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -12,6 +12,7 @@
 #include "RtpRelayPacket.h"
 #include "JanusSession.h"
 #include "IngestConnection.h"
+#include "RelayThreadPool.h"
 
 extern "C"
 {
@@ -32,7 +33,10 @@ class FtlStream
 {
 public:
     /* Constructor/Destructor */
-    FtlStream(const std::shared_ptr<IngestConnection> ingestConnection, const uint16_t mediaPort);
+    FtlStream(
+        const std::shared_ptr<IngestConnection> ingestConnection,
+        const uint16_t mediaPort,
+        const std::shared_ptr<RelayThreadPool> relayThreadPool);
 
     /* Public methods */
     void Start();
@@ -64,6 +68,7 @@ private:
     /* Private members */
     const std::shared_ptr<IngestConnection> ingestConnection;
     const uint16_t mediaPort; // Port that this stream is listening on
+    const std::shared_ptr<RelayThreadPool> relayThreadPool;
     janus_rtp_switching_context rtpSwitchingContext;
     int mediaSocketHandle;
     std::thread streamThread;
@@ -75,7 +80,6 @@ private:
     /* Private methods */
     void ingestConnectionClosed(IngestConnection& connection);
     void startStreamThread();
-    void relayRtpPacket(RtpRelayPacket rtpPacket);
     void handlePing(janus_rtp_header* rtpHeader, uint16_t length);
     void handleSenderReport(janus_rtp_header* rtpHeader, uint16_t length);
 };

--- a/FtlStreamStore.cpp
+++ b/FtlStreamStore.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "FtlStreamStore.h"
+#include "FtlStream.h"
 
 #include <stdexcept>
 

--- a/FtlStreamStore.h
+++ b/FtlStreamStore.h
@@ -10,13 +10,13 @@
 
 #pragma once
 
-#include "FtlStream.h"
-#include "JanusSession.h"
-
 #include <memory>
 #include <map>
 #include <set>
 #include <mutex>
+
+class FtlStream;
+class JanusSession;
 
 /**
  * @brief Handles storage and retrieval of FTL stream instances and associated viewer sessions

--- a/JanusFtl.h
+++ b/JanusFtl.h
@@ -68,13 +68,14 @@ private:
     /* Members */
     janus_plugin* pluginHandle;
     janus_callbacks* janusCore;
-    std::unique_ptr<IngestServer> ingestServer;
     std::shared_ptr<CredStore> credStore;
+    std::shared_ptr<FtlStreamStore> ftlStreamStore;
+    std::shared_ptr<RelayThreadPool> relayThreadPool;
+    std::unique_ptr<IngestServer> ingestServer;
     uint16_t minMediaPort = 9000;
     uint16_t maxMediaPort = 65535;
     std::mutex sessionsMutex;
     std::map<janus_plugin_session*, std::shared_ptr<JanusSession>> sessions;
-    std::unique_ptr<FtlStreamStore> ftlStreamStore;
     std::mutex portAssignmentMutex;
 
     /* Private methods */

--- a/JanusSession.h
+++ b/JanusSession.h
@@ -10,13 +10,15 @@
 
 #pragma once
 
-#include "FtlStream.h"
 #include "RtpRelayPacket.h"
+
 extern "C"
 {
     #include <plugins/plugin.h>
 }
 #include <memory>
+#include <queue>
+#include <condition_variable>
 
 class FtlStream; // Forward declare, circular reference
 
@@ -27,7 +29,7 @@ public:
     JanusSession(janus_plugin_session* handle, janus_callbacks* janusCore);
 
     /* Public methods */
-    void RelayRtpPacket(RtpRelayPacket rtpPacket);
+    void SendRtpPacket(RtpRelayPacket rtpPacket);
     void ResetRtpSwitchingContext();
     
     /* Getters/setters */
@@ -39,6 +41,7 @@ public:
 
 private:
     bool isStarted = false;
+    bool isStopping = false;
     janus_plugin_session* handle;
     janus_callbacks* janusCore;
     janus_rtp_switching_context rtpSwitchingContext;

--- a/RelayThreadPool.cpp
+++ b/RelayThreadPool.cpp
@@ -1,0 +1,132 @@
+/**
+ * @file RelayThreadPool.cpp
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @version 0.1
+ * @date 2020-08-28
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#include "RelayThreadPool.h"
+#include "FtlStreamStore.h"
+#include "FtlStream.h"
+
+extern "C"
+{
+    #include <debug.h>
+}
+
+#pragma region Constructor/Destructor
+RelayThreadPool::RelayThreadPool(
+    std::shared_ptr<FtlStreamStore> ftlStreamStore,
+    unsigned int threadCount) : 
+    ftlStreamStore(ftlStreamStore),
+    threadCount(threadCount)
+{ }
+#pragma endregion
+
+#pragma region Public methods
+void RelayThreadPool::Start()
+{
+    std::lock_guard<std::mutex> lock(threadVectorMutex);
+    for (unsigned int i = 0; i < threadCount; ++i)
+    {
+        auto thread = std::thread(&RelayThreadPool::relayThreadMethod, this, i);
+        thread.detach();
+        relayThreads[i] = std::move(thread);
+    }
+}
+
+void RelayThreadPool::Stop()
+{
+    SetThreadCount(0);
+
+    // TODO: Wait for threads to exit
+}
+
+void RelayThreadPool::RelayPacket(RtpRelayPacket packet)
+{
+    {
+        std::lock_guard<std::mutex> lock(relayMutex);
+        packetRelayQueue.push(packet);
+    }
+    relayThreadCondition.notify_one();
+}
+
+void RelayThreadPool::SetThreadCount(unsigned int newThreadCount)
+{
+    std::lock_guard<std::mutex> lock(threadVectorMutex);
+    if (isStarted && (newThreadCount > threadCount))
+    {
+        for (unsigned int i = threadCount; i < newThreadCount; ++i)
+        {
+            auto thread = std::thread(&RelayThreadPool::relayThreadMethod, this, i);
+            thread.detach();
+            relayThreads[i] = std::move(thread);
+        }
+    }
+    threadCount = newThreadCount;
+}
+#pragma endregion
+
+#pragma region Private methods
+void RelayThreadPool::relayThreadMethod(unsigned int threadNumber)
+{
+    JANUS_LOG(LOG_INFO, "FTL: Relay thread pool thread #%d started.\n", threadNumber);
+    std::unique_lock<std::mutex> lock(relayMutex);
+
+    while (true)
+    {
+        // Wait to be signaled that we have new packets to process.
+        // NOTE: `wait` will automatically release the lock until the condition
+        // variable is triggered, at which point it will hold the lock again.
+        relayThreadCondition.wait(lock,
+            [this, threadNumber]()
+            {
+                return (packetRelayQueue.size() > 0) || (threadCount < threadNumber);
+            });
+
+        // If we're stopping, release the lock and exit the thread.
+        if (threadCount < threadNumber)
+        {
+            break;
+        }
+
+        // Pop a packet off of the queue, then clear and unlock the mutex so it can continue
+        // being filled while we're processing.
+        RtpRelayPacket packet = std::move(packetRelayQueue.front());
+        packetRelayQueue.pop();
+        lock.unlock();
+
+        // Find the stream we're sending this to the viewers of
+        std::shared_ptr<FtlStream> originStream = 
+            ftlStreamStore->GetStreamByChannelId(packet.channelId);
+
+        if (originStream == nullptr)
+        {
+            JANUS_LOG(
+                LOG_WARN,
+                "FTL: Packet relay failed for non-existant stream with channel ID %lu\n",
+                packet.channelId);
+            continue;
+        }
+
+        std::list<std::shared_ptr<JanusSession>> channelSessions = 
+            originStream->GetViewers();
+        for (const auto& session : channelSessions)
+        {
+            session->SendRtpPacket(packet);
+        }
+
+        lock.lock();
+    }
+
+    // Remove from thread pool
+    {
+        std::lock_guard<std::mutex> threadPoolLock(threadVectorMutex);
+        relayThreads.erase(threadNumber);
+    }
+    JANUS_LOG(LOG_INFO, "FTL: Relay thread pool thread #%d terminated.\n", threadNumber);
+}
+#pragma endregion

--- a/RelayThreadPool.h
+++ b/RelayThreadPool.h
@@ -1,0 +1,53 @@
+/**
+ * @file RelayThreadPool.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @version 0.1
+ * @date 2020-08-28
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#pragma once
+
+#include "RtpRelayPacket.h"
+
+#include <memory>
+#include <mutex>
+#include <map>
+#include <queue>
+#include <thread>
+#include <condition_variable>
+
+class FtlStreamStore;
+class FtlStream;
+
+class RelayThreadPool
+{
+public:
+    /* Constructor/Destructor */
+    RelayThreadPool(
+        std::shared_ptr<FtlStreamStore> ftlStreamStore,
+        unsigned int threadCount = DEFAULT_THREAD_COUNT);
+
+    /* Public methods */
+    void Start();
+    void Stop();
+    void RelayPacket(RtpRelayPacket packet);
+    void SetThreadCount(unsigned int newThreadCount);
+private:
+    /* Private members */
+    static const unsigned int DEFAULT_THREAD_COUNT = 5;
+    const std::shared_ptr<FtlStreamStore> ftlStreamStore;
+    bool isStarted = false;
+    unsigned int threadCount;
+    // Packet relay threads
+    std::mutex threadVectorMutex;
+    std::mutex relayMutex;
+    std::map<unsigned int, std::thread> relayThreads;
+    std::condition_variable relayThreadCondition;
+    std::queue<RtpRelayPacket> packetRelayQueue;
+
+    /* Private methods */
+    void relayThreadMethod(unsigned int threadNumber);
+};

--- a/RtpRelayPacket.h
+++ b/RtpRelayPacket.h
@@ -14,6 +14,8 @@ extern "C"
 {
     #include <rtp.h>
 }
+#include <memory>
+#include <vector>
 
 enum class RtpRelayPacketKind
 {
@@ -23,7 +25,7 @@ enum class RtpRelayPacketKind
 
 struct RtpRelayPacket
 {
-    janus_rtp_header* rtpHeader;
-    uint16_t rtpHeaderLength;
+    std::shared_ptr<std::vector<unsigned char>> rtpPacketPayload;
     RtpRelayPacketKind type;
+    uint64_t channelId;
 };

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,8 @@ sources = files([
     'IngestServer.cpp',
     'janus_ftl.cpp',
     'JanusSession.cpp',
-    'JanusFtl.cpp'
+    'JanusFtl.cpp',
+    'RelayThreadPool.cpp'
 ])
 
 deps = [


### PR DESCRIPTION
This change introduces a new `RelayThreadPool` class to handle taking incoming packets from `FtlStream` objects and relaying them to associated `JanusSession` viewers without clogging up the `FtlStream` thread and delaying new packets from being processed.