### PR TITLE
📩 Add NACK support for incoming streams

### DIFF
--- a/FtlRtp.h
+++ b/FtlRtp.h
@@ -1,0 +1,22 @@
+/**
+ * @file FtlRtp.h
+ * @author Hayden McAfee(hayden@outlook.com)
+ * @brief A few utility type defs for FTL/RTP data
+ * @version 0.1
+ * @date 2020-08-29
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#pragma once
+#include <cstdint>
+
+/* FTL data types */
+typedef uint32_t ftl_channel_id_t;
+
+/* RTP data types */
+typedef uint8_t rtp_payload_type_t;
+typedef uint16_t rtp_sequence_num_t;
+typedef uint32_t rtp_ssrc_t;
+typedef uint32_t rtp_timestamp_t;

--- a/FtlStream.cpp
+++ b/FtlStream.cpp
@@ -13,8 +13,10 @@
 #include <algorithm>
 extern "C"
 {
+    #include <unistd.h>
     #include <debug.h>
     #include <sys/time.h>
+    #include <rtcp.h>
 }
 
 #pragma region Constructor/Destructor
@@ -37,6 +39,12 @@ FtlStream::FtlStream(
 #pragma region Public methods
 void FtlStream::Start()
 {
+    // Set up rtcp address
+    rtcpAddress.sin_family = AF_INET;
+    rtcpAddress.sin_addr.s_addr = ingestConnection->GetAcceptAddress().sin_addr.s_addr;
+    rtcpAddress.sin_port = htons(mediaPort);
+
+    // Start listening for incoming packets
     streamThread = std::thread(&FtlStream::startStreamThread, this);
     streamThread.detach();
 }
@@ -68,7 +76,7 @@ void FtlStream::SetOnClosed(std::function<void (FtlStream&)> callback)
 #pragma endregion
 
 #pragma region Getters/Setters
-uint64_t FtlStream::GetChannelId()
+ftl_channel_id_t FtlStream::GetChannelId()
 {
     return ingestConnection->GetChannelId();
 }
@@ -134,7 +142,7 @@ void FtlStream::ingestConnectionClosed(IngestConnection& connection)
 
 void FtlStream::startStreamThread()
 {
-    struct sockaddr_in socketAddress;
+    sockaddr_in socketAddress;
     socketAddress.sin_family = AF_INET;
     socketAddress.sin_addr.s_addr = htonl(INADDR_ANY);
     socketAddress.sin_port = htons(mediaPort);
@@ -146,7 +154,11 @@ void FtlStream::startStreamThread()
         (const sockaddr*)&socketAddress,
         sizeof(socketAddress));
 
-    JANUS_LOG(LOG_INFO, "FTL: Started media connection on port %d\n", mediaPort);
+    sockaddr_in ingestAddress = ingestConnection->GetAcceptAddress();
+    char ipBuf[32];
+    inet_ntop(AF_INET, &ingestAddress.sin_addr.s_addr, &ipBuf[0], sizeof(ipBuf));
+
+    JANUS_LOG(LOG_INFO, "FTL: Started media connection for %s on port %d\n", ipBuf, mediaPort);
     switch (bindResult)
     {
     case 0:
@@ -163,7 +175,7 @@ void FtlStream::startStreamThread()
 
     // Set up some values we'll be using in our read thread
     socklen_t addrlen;
-    struct sockaddr_storage remote;
+    sockaddr_in remote;
     char buffer[1500] = { 0 };
     int bytesRead = 0;
     // Set up poll
@@ -213,16 +225,25 @@ void FtlStream::startStreamThread()
                 (struct sockaddr*)&remote,
                 &addrlen);
 
-            if (bytesRead < 12)
+            if (remote.sin_addr.s_addr != ingestConnection->GetAcceptAddress().sin_addr.s_addr)
             {
-                // This packet is too small to have an RTP header.
-                JANUS_LOG(LOG_WARN, "FTL: Received non-RTP packet.");
+                JANUS_LOG(
+                    LOG_ERR,
+                    "FTL: Channel %u received packet from unexpected address.\n",
+                    GetChannelId());
                 continue;
             }
 
+            if (bytesRead < 12)
+            {
+                // This packet is too small to have an RTP header.
+                JANUS_LOG(LOG_WARN, "FTL: Channel %u received non-RTP packet.\n", GetChannelId());
+                continue;
+            }
 
             // Parse out RTP packet
             janus_rtp_header* rtpHeader = (janus_rtp_header*)buffer;
+            rtp_sequence_num_t sequenceNumber = ntohs(rtpHeader->seq_number);
 
             // TODO: Send nacks for missing sequence numbers
             // see https://tools.ietf.org/html/rfc4585 Section 6.1
@@ -240,6 +261,8 @@ void FtlStream::startStreamThread()
                     .type = packetKind,
                     .channelId = GetChannelId()
                 });
+                markReceivedSequence(rtpHeader->type, sequenceNumber);
+                processLostPackets(remote, rtpHeader->type, sequenceNumber, rtpHeader->timestamp);
             }
             else
             {
@@ -277,6 +300,141 @@ void FtlStream::startStreamThread()
     }
 }
 
+void FtlStream::markReceivedSequence(
+    rtp_payload_type_t payloadType,
+    rtp_sequence_num_t receivedSequence)
+{
+    // If this sequence was previously marked as lost, remove it
+    if (lostPackets.count(payloadType) > 0)
+    {
+        auto& lostPayloadPackets = lostPackets[payloadType];
+        if (lostPayloadPackets.count(receivedSequence) > 0)
+        {
+            lostPayloadPackets.erase(receivedSequence);
+        }
+    }
+
+    // If this is the first sequence, record it
+    if (latestSequence.count(payloadType) <= 0)
+    {
+        latestSequence[payloadType] = receivedSequence;
+        JANUS_LOG(
+            LOG_INFO,
+            "FTL: Channel %u first %u sequence: %u\n",
+            GetChannelId(),
+            payloadType,
+            receivedSequence);
+    }
+    else
+    {
+        // Make sure we're actually the latest
+        auto lastSequence = latestSequence[payloadType];
+        if (lastSequence < receivedSequence)
+        {
+            // JANUS_LOG(
+            //     LOG_INFO,
+            //     "FTL: %u old: %u new: %u lost: %u.\n",
+            //     payloadType,
+            //     lastSequence,
+            //     receivedSequence,
+            //     (receivedSequence - lastSequence + 1));
+            // Identify any lost packets between the last sequence
+            if (lostPackets.count(payloadType) <= 0)
+            {
+                lostPackets[payloadType] = std::set<rtp_sequence_num_t>();
+            }
+            for (auto seq = lastSequence + 1; seq < receivedSequence; ++seq)
+            {
+                lostPackets[payloadType].insert(seq);
+            }
+            if (receivedSequence - lastSequence > 1)
+            {
+                JANUS_LOG(
+                    LOG_WARN,
+                    "FTL: Channel %u PL %u lost %u packets. %lu total lost.\n",
+                    GetChannelId(),
+                    payloadType,
+                    (receivedSequence - (lastSequence + 1)),
+                    lostPackets[payloadType].size());
+            }
+            latestSequence[payloadType] = receivedSequence;
+        }
+    }
+}
+
+void FtlStream::processLostPackets(
+    sockaddr_in remote,
+    rtp_payload_type_t payloadType,
+    rtp_sequence_num_t currentSequence,
+    rtp_timestamp_t currentTimestamp)
+{
+    if (lostPackets.count(payloadType) > 0)
+    {
+        auto& lostPayloadPackets = lostPackets[payloadType];
+        for (auto it = lostPayloadPackets.cbegin(); it != lostPayloadPackets.cend();)
+        {
+            const auto& lostPacketSequence = *it;
+
+            // If this 'lost' packet came from the future, get rid of it
+            if (lostPacketSequence > currentSequence)
+            {
+                it = lostPayloadPackets.erase(it);
+                continue;
+            }
+
+            // TODO: Otherwise, ask for re-transmission
+            rtp_ssrc_t ssrc = GetVideoSsrc();
+            if (payloadType == GetAudioPayloadType())
+            {
+                ssrc = GetAudioSsrc();
+            }
+            char nackBuf[120];
+            janus_rtcp_header *rtcpHeader = reinterpret_cast<janus_rtcp_header*>(nackBuf);
+            rtcpHeader->version = 2;
+            rtcpHeader->type = RTCP_RTPFB;
+            rtcpHeader->rc = 1;
+            janus_rtcp_fb* rtcpFeedback = reinterpret_cast<janus_rtcp_fb*>(rtcpHeader);
+            rtcpFeedback->media = htonl(ssrc);
+            rtcpFeedback->ssrc = htonl(ssrc);
+            janus_rtcp_nack* rtcpNack = reinterpret_cast<janus_rtcp_nack*>(rtcpFeedback->fci);
+            rtcpNack->pid = htons(lostPacketSequence);
+            rtcpNack->blp = 0;
+            rtcpHeader->length = htons(3);
+
+            int res = sendto(
+                mediaSocketHandle,
+                nackBuf,
+                16,
+                0,
+                reinterpret_cast<sockaddr*>(&remote),
+                sizeof(remote));
+            if (res == -1)
+            {
+                JANUS_LOG(
+                    LOG_ERR,
+                    "FTL: Channel %u PL %u NACK failed: %d\n",
+                    GetChannelId(),
+                    payloadType,
+                    errno);
+            }
+            
+            char ipBuf[32];
+            inet_ntop(AF_INET, &remote.sin_addr.s_addr, &ipBuf[0], sizeof(ipBuf));
+
+            // Sent! Take it out of the list for now.
+            it = lostPayloadPackets.erase(it);
+
+            JANUS_LOG(
+                    LOG_INFO,
+                    "FTL: Channel %u PL %u sent NACK to %s for seq %u\n",
+                    GetChannelId(),
+                    payloadType,
+                    ipBuf,
+                    lostPacketSequence);
+        }
+    }
+}
+
 void FtlStream::handlePing(janus_rtp_header* rtpHeader, uint16_t length)
 {
     // These pings are useless - FTL tries to determine 'ping' by having a timestamp
@@ -292,7 +450,7 @@ void FtlStream::handleSenderReport(janus_rtp_header* rtpHeader, uint16_t length)
     // We expect this packet to be 28 bytes big.
     if (length != 28)
     {
-        JANUS_LOG(LOG_WARN, "Invalid sender report packet of length %d (expect 28)\n", length);
+        JANUS_LOG(LOG_WARN, "FTL: Invalid sender report packet of length %d (expect 28)\n", length);
     }
     // char* packet = reinterpret_cast<char*>(rtpHeader);
     // uint32_t ssrc              = ntohl(*reinterpret_cast<uint32_t*>(packet + 4));

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -10,9 +10,9 @@
 #pragma once
 
 #include "RtpRelayPacket.h"
-#include "JanusSession.h"
 #include "IngestConnection.h"
 #include "RelayThreadPool.h"
+#include "FtlRtp.h"
 
 extern "C"
 {
@@ -25,8 +25,9 @@ extern "C"
 #include <functional>
 #include <list>
 #include <mutex>
+#include <set>
 
-class JanusSession; // Forward declare, circular reference
+class JanusSession;
 
 // Kind of a combo between janus_streaming_mountpoint and janus_streaming_rtp_source
 class FtlStream
@@ -46,29 +47,30 @@ public:
     void SetOnClosed(std::function<void (FtlStream&)> callback);
     
     /* Getters/Setters */
-    uint64_t GetChannelId();
+    ftl_channel_id_t GetChannelId();
     uint16_t GetMediaPort();
     bool GetHasVideo();
     bool GetHasAudio();
     VideoCodecKind GetVideoCodec();
     AudioCodecKind GetAudioCodec();
-    uint32_t GetAudioSsrc();
-    uint32_t GetVideoSsrc();
-    uint8_t GetAudioPayloadType();
-    uint8_t GetVideoPayloadType();
+    rtp_ssrc_t GetAudioSsrc();
+    rtp_ssrc_t GetVideoSsrc();
+    rtp_payload_type_t GetAudioPayloadType();
+    rtp_payload_type_t GetVideoPayloadType();
     std::list<std::shared_ptr<JanusSession>> GetViewers();
 
 private:
     /* Constants */
-    static constexpr uint64_t MICROSECONDS_PER_SECOND        = 1000000;
-    static constexpr float    MICROSECONDS_PER_MILLISECOND   = 1000.0f;
-    static constexpr uint8_t  FTL_PAYLOAD_TYPE_SENDER_REPORT = 200;
-    static constexpr uint8_t  FTL_PAYLOAD_TYPE_PING          = 250;
+    static constexpr uint64_t            MICROSECONDS_PER_SECOND        = 1000000;
+    static constexpr float               MICROSECONDS_PER_MILLISECOND   = 1000.0f;
+    static constexpr rtp_payload_type_t  FTL_PAYLOAD_TYPE_SENDER_REPORT = 200;
+    static constexpr rtp_payload_type_t  FTL_PAYLOAD_TYPE_PING          = 250;
 
     /* Private members */
     const std::shared_ptr<IngestConnection> ingestConnection;
     const uint16_t mediaPort; // Port that this stream is listening on
     const std::shared_ptr<RelayThreadPool> relayThreadPool;
+    sockaddr_in rtcpAddress;
     janus_rtp_switching_context rtpSwitchingContext;
     int mediaSocketHandle;
     std::thread streamThread;
@@ -76,10 +78,14 @@ private:
     std::list<std::shared_ptr<JanusSession>> viewerSessions;
     std::function<void (FtlStream&)> onClosed;
     bool stopping = false;
+    std::map<rtp_payload_type_t, rtp_sequence_num_t> latestSequence;
+    std::map<rtp_payload_type_t, std::set<rtp_sequence_num_t>> lostPackets;
 
     /* Private methods */
     void ingestConnectionClosed(IngestConnection& connection);
     void startStreamThread();
+    void markReceivedSequence(rtp_payload_type_t payloadType, rtp_sequence_num_t receivedSequence);
+    void processLostPackets(sockaddr_in remoteAddr, rtp_payload_type_t payloadType, rtp_sequence_num_t currentSequence, rtp_timestamp_t currentTimestamp);
     void handlePing(janus_rtp_header* rtpHeader, uint16_t length);
     void handleSenderReport(janus_rtp_header* rtpHeader, uint16_t length);
 };

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -70,7 +70,6 @@ private:
     const std::shared_ptr<IngestConnection> ingestConnection;
     const uint16_t mediaPort; // Port that this stream is listening on
     const std::shared_ptr<RelayThreadPool> relayThreadPool;
-    sockaddr_in rtcpAddress;
     janus_rtp_switching_context rtpSwitchingContext;
     int mediaSocketHandle;
     std::thread streamThread;

--- a/FtlStreamStore.cpp
+++ b/FtlStreamStore.cpp
@@ -9,6 +9,10 @@
 
 #include "FtlStreamStore.h"
 #include "FtlStream.h"
+extern "C"
+{
+    #include <debug.h>
+}
 
 #include <stdexcept>
 


### PR DESCRIPTION
This PR contains the following changes:
- Adds typedefs for some common RTP and FTL fields to help readability.
- Incoming FTL media packets that come from an IP address other than that of the initial ingest handshake will be rejected.
- Rudimentary logic to send NACK requests to FTL clients for packets that appear to have been lost.