### PR TITLE
🖼 Cache keyframes, and send them to viewers in response to PLI feedback

### DIFF
--- a/FtlStream.cpp
+++ b/FtlStream.cpp
@@ -448,12 +448,6 @@ void FtlStream::processKeyframePacket(std::shared_ptr<std::vector<unsigned char>
     // Part of our current keyframe?
     else if (timestamp == pendingKeyframe.rtpTimestamp)
     {
-        JANUS_LOG(
-            LOG_INFO,
-            "FTL: Channel %u addtl keyframe seq %u ts %u\n",
-            GetChannelId(),
-            sequence,
-            timestamp);
         pendingKeyframe.rtpPackets.push_back(rtpPacket);
     }
 }

--- a/FtlStream.cpp
+++ b/FtlStream.cpp
@@ -424,7 +424,7 @@ void FtlStream::processKeyframePacket(std::shared_ptr<std::vector<unsigned char>
         keyframeSentToViewers.clear();
 
         JANUS_LOG(
-            LOG_INFO,
+            LOG_VERB,
             "FTL: Channel %u keyframe complete ts %u w/ %lu packets\n",
             GetChannelId(),
             keyframe.rtpTimestamp,
@@ -444,7 +444,7 @@ void FtlStream::processKeyframePacket(std::shared_ptr<std::vector<unsigned char>
     if (isKeyframePacket && !pendingKeyframe.isCapturing)
     {
         JANUS_LOG(
-            LOG_INFO,
+            LOG_VERB,
             "FTL: Channel %u new keyframe seq %u ts %u\n",
             GetChannelId(),
             sequence,

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -102,6 +102,7 @@ private:
     void ingestConnectionClosed(IngestConnection& connection);
     void startStreamThread();
     void startStreamMetadataReportingThread();
+    bool isKeyframePacket(janus_rtp_header* rtpHeader, uint16_t length);
     void markReceivedSequence(rtp_payload_type_t payloadType, rtp_sequence_num_t receivedSequence);
     void processLostPackets(sockaddr_in remoteAddr, rtp_payload_type_t payloadType, rtp_sequence_num_t currentSequence, rtp_timestamp_t currentTimestamp);
     void handlePing(janus_rtp_header* rtpHeader, uint16_t length);

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -102,6 +102,7 @@ private:
     std::mutex keyframeMutex;
     Keyframe keyframe;
     Keyframe pendingKeyframe;
+    std::set<std::shared_ptr<JanusSession>> keyframeSentToViewers;
 
     /* Private methods */
     void ingestConnectionClosed(IngestConnection& connection);

--- a/JanusFtl.cpp
+++ b/JanusFtl.cpp
@@ -142,7 +142,7 @@ json_t* JanusFtl::HandleAdminMessage(json_t* message)
 
 void JanusFtl::SetupMedia(janus_plugin_session* handle)
 {
-    JANUS_LOG(LOG_INFO, "FTL: SetupMedia");
+    JANUS_LOG(LOG_INFO, "FTL: SetupMedia\n");
 
     std::shared_ptr<JanusSession> session;
     {
@@ -164,6 +164,7 @@ void JanusFtl::SetupMedia(janus_plugin_session* handle)
 
     session->ResetRtpSwitchingContext();
     session->SetIsStarted(true);
+    ftlStream->SendKeyframeToViewer(session);
 }
 
 void JanusFtl::IncomingRtp(janus_plugin_session* handle, janus_plugin_rtp* packet)
@@ -179,6 +180,7 @@ void JanusFtl::IncomingRtcp(janus_plugin_session* handle, janus_plugin_rtcp* pac
 void JanusFtl::DataReady(janus_plugin_session* handle)
 {
     // TODO
+    JANUS_LOG(LOG_INFO, "FTL: DataReady\n");
 }
 
 void JanusFtl::HangUpMedia(janus_plugin_session* handle)

--- a/JanusFtl.cpp
+++ b/JanusFtl.cpp
@@ -357,12 +357,10 @@ void JanusFtl::handlePsfbRtcpPacket(janus_plugin_session* handle, janus_rtcp_hea
     {
     case 1:
     {
-        JANUS_LOG(LOG_INFO, "FTL: Received PLI packet! Sending Keyframe...\n");
         std::shared_ptr<JanusSession> session = sessions.at(handle);
         std::shared_ptr<FtlStream> viewingStream = ftlStreamStore->GetStreamBySession(session);
         if (viewingStream != nullptr)
         {
-            // TODO: Debounce...
             viewingStream->SendKeyframeToViewer(session);
         }
         break;

--- a/JanusFtl.cpp
+++ b/JanusFtl.cpp
@@ -17,6 +17,7 @@
 extern "C"
 {
     #include <apierror.h>
+    #include <rtcp.h>
     #include <debug.h>
 }
 
@@ -169,12 +170,44 @@ void JanusFtl::SetupMedia(janus_plugin_session* handle)
 
 void JanusFtl::IncomingRtp(janus_plugin_session* handle, janus_plugin_rtp* packet)
 {
-    // TODO
+    // We don't care about incoming rtp, we're send-only
 }
 
 void JanusFtl::IncomingRtcp(janus_plugin_session* handle, janus_plugin_rtcp* packet)
 {
-    // TODO
+    uint16_t totalLength = packet->length;
+    janus_rtcp_header* rtcpHeader = reinterpret_cast<janus_rtcp_header*>(packet->buffer);
+
+    // Turns out these packets often come in big 'ol bundles (compound packets)
+    // so let's sort through them.
+    while (true)
+    {
+        switch (rtcpHeader->type)
+        {
+        case RTCP_RR:
+            break;
+        case RTCP_PSFB:
+            handlePsfbRtcpPacket(handle, rtcpHeader);
+            break;
+        default:
+            JANUS_LOG(LOG_INFO, "FTL: Got unknown RTCP packet! Type: %d\n", rtcpHeader->type);
+            break;
+        }
+
+        // Check if we've reached the end of the compound packet, and if not, advance to the next
+        uint16_t packetLength = ntohs(rtcpHeader->length);
+        if (packetLength == 0)
+        {
+            break;
+        }
+        totalLength -= (packetLength * 4) + 4;
+        if (totalLength <= 0)
+        {
+            break;
+        }
+        rtcpHeader = reinterpret_cast<janus_rtcp_header*>(
+            reinterpret_cast<uint32_t*>(rtcpHeader) + packetLength + 1);
+    }
 }
 
 void JanusFtl::DataReady(janus_plugin_session* handle)
@@ -318,6 +351,27 @@ void JanusFtl::ftlStreamClosed(FtlStream& ftlStream)
     ftlStreamStore->RemoveStream(stream);
 }
 
+void JanusFtl::handlePsfbRtcpPacket(janus_plugin_session* handle, janus_rtcp_header* packet)
+{
+    switch (packet->rc)
+    {
+    case 1:
+    {
+        JANUS_LOG(LOG_INFO, "FTL: Received PLI packet! Sending Keyframe...\n");
+        std::shared_ptr<JanusSession> session = sessions.at(handle);
+        std::shared_ptr<FtlStream> viewingStream = ftlStreamStore->GetStreamBySession(session);
+        if (viewingStream != nullptr)
+        {
+            // TODO: Debounce...
+            viewingStream->SendKeyframeToViewer(session);
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
 janus_plugin_result* JanusFtl::generateMessageErrorResponse(int errorCode, std::string errorMessage)
 {
     json_t *event = json_object();
@@ -454,10 +508,10 @@ std::string JanusFtl::generateSdpOffer(
             "m=video 1 RTP/SAVPF " << videoPayloadType << "\r\n" <<
             "c=IN IP4 1.1.1.1\r\n" <<
             "a=rtpmap:" << videoPayloadType << " " << videoCodec << "/90000\r\n" <<
-            "a=fmtp:" << videoPayloadType << " profile-level-id=42e01f;packetization-mode=1;"
-            //"a=rtcp-fb:96 nack\r\n" <<            // Send us NACK's
-            //"a=rtcp-fb:96 nack pli\r\n" <<        // Send us picture-loss-indicators
-            //"a=rtcp-fb:96 nack goog-remb\r\n" <<  // Send some congestion indicator thing
+            "a=fmtp:" << videoPayloadType << " profile-level-id=42e01f;packetization-mode=1;\r\n"
+            "a=rtcp-fb:" << videoPayloadType << " nack\r\n" <<            // Send us NACK's
+            "a=rtcp-fb:" << videoPayloadType << " nack pli\r\n" <<        // Send us picture-loss-indicators
+            // "a=rtcp-fb:96 nack goog-remb\r\n" <<  // Send some congestion indicator thing
             "a=sendonly\r\n" <<
             "a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid\r\n";
     }

--- a/JanusFtl.h
+++ b/JanusFtl.h
@@ -13,6 +13,7 @@
 extern "C"
 {
     #include <plugins/plugin.h>
+    #include <rtcp.h>
 }
 
 #include "Configuration.h"
@@ -84,6 +85,8 @@ private:
     void initServiceConnection();
     uint16_t newIngestFtlStream(std::shared_ptr<IngestConnection> connection);
     void ftlStreamClosed(FtlStream& ftlStream);
+    // Packet handling
+    void handlePsfbRtcpPacket(janus_plugin_session* handle, janus_rtcp_header* packet);
     // Message handling
     janus_plugin_result* generateMessageErrorResponse(int errorCode, std::string errorMessage);
     janus_plugin_result* handleWatchMessage(std::shared_ptr<JanusSession> session, JsonPtr message, char* transaction);

--- a/JanusSession.h
+++ b/JanusSession.h
@@ -20,8 +20,6 @@ extern "C"
 #include <queue>
 #include <condition_variable>
 
-class FtlStream; // Forward declare, circular reference
-
 class JanusSession
 {
 public:

--- a/Keyframe.h
+++ b/Keyframe.h
@@ -17,7 +17,8 @@
 
 struct Keyframe
 {
-    Keyframe() : rtpTimestamp(0) { }
+    Keyframe() : isCapturing(false), rtpTimestamp(0) { }
+    bool isCapturing;
     uint32_t rtpTimestamp;
     std::list<std::shared_ptr<std::vector<unsigned char>>> rtpPackets;
 };

--- a/Keyframe.h
+++ b/Keyframe.h
@@ -1,0 +1,23 @@
+/**
+ * @file Keyframe.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @version 0.1
+ * @date 2020-09-11
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <list>
+#include <memory>
+#include <vector>
+
+struct Keyframe
+{
+    Keyframe() : rtpTimestamp(0) { }
+    uint32_t rtpTimestamp;
+    std::list<std::shared_ptr<std::vector<unsigned char>>> rtpPackets;
+};


### PR DESCRIPTION
This change introduces caching of keyframes by `FtlStream`, plus sending of those keyframes to viewers when a new viewer connects (so they get an immediate image), as well as when a [picture-loss-indication](https://tools.ietf.org/html/rfc4585#section-6.3.1) is received to assist in recovering of lost data needed to decode the video stream.

Further stream stability can likely be achieved by implementing forward error correction (tracked in #14).

This also caches the needed data to generate thumbnail images (tracked in #16).