### PR TITLE
💥 Fix build to include libraries and defines needed for HTTPS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,9 @@ sources = files([
 deps = [
     dependency('glib-2.0'),
     dependency('libsrtp2'),
-    dependency('openssl'),
-    dependency('jansson')
+    dependency('jansson'),
+    dependency('libssl'),
+    dependency('libcrypto')
 ]
 
 incdir = include_directories(
@@ -30,7 +31,7 @@ incdir = include_directories(
     './cpp-httplib'
 )
 
-cppargs = '-Wno-unknown-pragmas'
+cppargs = ['-Wno-unknown-pragmas', '-DCPPHTTPLIB_OPENSSL_SUPPORT']
 
 shared_library(
     'janus_ftl',


### PR DESCRIPTION
Neglected to add the libraries and defines needed to enable HTTPS in the [cpp-httplib](https://github.com/yhirose/cpp-httplib) being used for the `GlimeshServiceConnection`.