### PR TITLE
🖇 Fix a reference to free'd memory, properly spin down relay threads

### DIFF
--- a/FtlStream.cpp
+++ b/FtlStream.cpp
@@ -528,7 +528,7 @@ void FtlStream::processLostPackets(
         auto& lostPayloadPackets = lostPackets[payloadType];
         for (auto it = lostPayloadPackets.cbegin(); it != lostPayloadPackets.cend();)
         {
-            const auto& lostPacketSequence = *it;
+            const auto lostPacketSequence = *it;
 
             // If this 'lost' packet came from the future, get rid of it
             if (lostPacketSequence > currentSequence)

--- a/RelayThreadPool.h
+++ b/RelayThreadPool.h
@@ -12,9 +12,10 @@
 
 #include "RtpRelayPacket.h"
 
+#include <atomic>
 #include <memory>
 #include <mutex>
-#include <map>
+#include <vector>
 #include <queue>
 #include <thread>
 #include <condition_variable>
@@ -28,23 +29,21 @@ public:
     /* Constructor/Destructor */
     RelayThreadPool(
         std::shared_ptr<FtlStreamStore> ftlStreamStore,
-        unsigned int threadCount = DEFAULT_THREAD_COUNT);
+        unsigned int threadCount = std::thread::hardware_concurrency());
 
     /* Public methods */
     void Start();
     void Stop();
     void RelayPacket(RtpRelayPacket packet);
-    void SetThreadCount(unsigned int newThreadCount);
 private:
     /* Private members */
-    static const unsigned int DEFAULT_THREAD_COUNT = 5;
     const std::shared_ptr<FtlStreamStore> ftlStreamStore;
-    bool isStarted = false;
     unsigned int threadCount;
+    std::atomic<bool> stopping { false };
     // Packet relay threads
     std::mutex threadVectorMutex;
     std::mutex relayMutex;
-    std::map<unsigned int, std::thread> relayThreads;
+    std::vector<std::thread> relayThreads;
     std::condition_variable relayThreadCondition;
     std::queue<RtpRelayPacket> packetRelayQueue;
 


### PR DESCRIPTION
Two-in-one special!

1. Fixed an instance where we were reading data from a location that had already been free'd.
2. Joined relay threads when the relay thread pool is being stopped rather than just hoping they end themselves before the process goes down.

Fixes #15 

This change also sets the number of default relay threads to the value returned by [`std::thread::hardware_concurrency`](https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency), which should get us close to the most efficient number of threads to run on a particular machine.