### PR TITLE
💣 Fixed another JSON double free in `GlimeshServiceConnection`

### DIFF
--- a/IngestServer.cpp
+++ b/IngestServer.cpp
@@ -33,7 +33,7 @@ IngestServer::IngestServer(
 #pragma region Public methods
 void IngestServer::Start()
 {
-    sockaddr_in socketAddress;
+    sockaddr_in socketAddress = { 0 };
     socketAddress.sin_family = AF_INET;
     socketAddress.sin_addr.s_addr = htonl(INADDR_ANY);
     socketAddress.sin_port = htons(listenPort);
@@ -110,7 +110,7 @@ void IngestServer::startListenThread()
         }
         else
         {
-            sockaddr_in acceptAddress;
+            sockaddr_in acceptAddress = { 0 };
             socklen_t acceptLen = sizeof(acceptAddress);
             getpeername(connectionHandle, reinterpret_cast<sockaddr*>(&acceptAddress), &acceptLen);
             JANUS_LOG(LOG_INFO, "FTL: Ingest server accepted connection...\n");


### PR DESCRIPTION
`json_pack` was taking ownership of the reference to our `JsonPtr variables` and freeing it on our behalf, so when we ended up freeing `variables` we'd hit a double free and occasional crash.

This change fixes that issue by using the identifier `O` instead of `o` to indicate to `json_pack` that it should only increment the ref count, not steal the reference.

There are also a couple of small valgrind fixes, initializing structs to 0 so we don't reference uninitialized bytes anywhere.

Additional logging was added to the access token expiration time logic, since we've been seeing issues where access tokens are being renewed too often.