### PR TITLE
📷 Add thumbnail support, plus retry logic to GlimeshServiceConnection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Install Dependency Packages
-      run: sudo apt update && sudo apt install libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build
+      run: sudo apt update && sudo apt install libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build libavcodec-dev
     - name: Install meson
       run: sudo -H pip3 install meson
     - name: Clone libnice

--- a/Configuration.h
+++ b/Configuration.h
@@ -29,6 +29,7 @@ public:
     std::string GetMyHostname();
     ServiceConnectionKind GetServiceConnectionKind();
     uint16_t GetServiceConnectionMetadataReportIntervalMs();
+    std::string GetDummyPreviewImagePath();
     // Glimesh Service Connection Values
     std::string GetGlimeshServiceHostname();
     uint16_t GetGlimeshServicePort();
@@ -41,6 +42,7 @@ private:
     std::string myHostname;
     ServiceConnectionKind serviceConnectionKind = ServiceConnectionKind::DummyServiceConnection;
     uint16_t serviceConnectionMetadataReportIntervalMs = 4000;
+    std::string dummyPreviewImagePath;
     // Glimesh Service Connection Backing Stores
     std::string glimeshServiceHostname = "localhost";
     uint16_t glimeshServicePort = 4000;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get -y install curl libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build
+RUN apt-get update && apt-get -y install curl libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build libavcodec-dev
 
 RUN pip3 install meson
 

--- a/DummyServiceConnection.cpp
+++ b/DummyServiceConnection.cpp
@@ -9,9 +9,32 @@
  */
 
 #include "DummyServiceConnection.h"
+#include "FtlExceptions.h"
 
-void DummyServiceConnection::Init()
+#include <fstream>
+#include <iostream>
+#include <linux/limits.h>
+#include <sys/stat.h>
+#include <sstream>
+#include <stdexcept>
+
+#pragma region Constructor/Destructor
+DummyServiceConnection::DummyServiceConnection(std::string previewSavePath) : 
+    previewSavePath(previewSavePath)
 { }
+#pragma endregion
+
+#pragma region Public methods
+void DummyServiceConnection::Init()
+{
+    // Make sure the path we're writing thumbnails to exists
+    if (recursiveMkDir(previewSavePath) != 0)
+    {
+        std::stringstream errStr;
+        errStr << "Could not create directory '" << previewSavePath << "' to save thumbnails.";
+        throw std::runtime_error(errStr.str());
+    }
+}
 
 std::string DummyServiceConnection::GetHmacKey(ftl_channel_id_t channelId)
 {
@@ -28,3 +51,57 @@ void DummyServiceConnection::UpdateStreamMetadata(ftl_stream_id_t streamId, Stre
 
 void DummyServiceConnection::EndStream(ftl_stream_id_t streamId)
 { }
+
+void DummyServiceConnection::SendJpegPreviewImage(
+    ftl_stream_id_t streamId,
+    std::vector<uint8_t> jpegData)
+{
+    std::stringstream pathStr;
+    pathStr << previewSavePath << "/" << streamId << ".jpg";
+
+    std::ofstream jpegFile;
+    jpegFile.open(pathStr.str().c_str());
+    if (jpegFile.fail())
+    {
+        std::stringstream errStr;
+        errStr << "Could not open file '" << pathStr.str().c_str() << "' for writing.";
+        throw ServiceConnectionCommunicationFailedException(errStr.str().c_str());
+    }
+
+    jpegFile.write(reinterpret_cast<const char*>(jpegData.data()), jpegData.size());
+    jpegFile.close();
+}
+#pragma endregion
+
+#pragma Private methods
+int DummyServiceConnection::recursiveMkDir(std::string path)
+{
+    errno = 0;
+
+    // Create every node along the path
+    for (size_t i = 1; i < path.size(); ++i)
+    {
+        if (path.at(i) == '/')
+        {
+            if (mkdir(path.substr(0, i).c_str(), S_IRWXU) != 0)
+            {
+                if (errno != EEXIST)
+                {
+                    return -1; 
+                }
+            }
+        }
+    }
+
+    // Create final dir
+    if (mkdir(path.c_str(), S_IRWXU) != 0)
+    {
+        if (errno != EEXIST)
+        {
+            return -1; 
+        }
+    }   
+
+    return 0;
+}
+#pragma endregion

--- a/DummyServiceConnection.h
+++ b/DummyServiceConnection.h
@@ -12,6 +12,8 @@
 
 #include "ServiceConnection.h"
 
+#include <string>
+
 /**
  * @brief
  * DummyServiceConnection is a generic service connection implementation that returns static
@@ -21,9 +23,26 @@ class DummyServiceConnection :
     public ServiceConnection
 {
 public:
+    /* Constructor/Destructor */
+    DummyServiceConnection(std::string previewSavePath);
+
+    // ServiceConnection
     void Init() override;
     std::string GetHmacKey(ftl_channel_id_t channelId) override;
     ftl_stream_id_t StartStream(ftl_channel_id_t channelId) override;
     void UpdateStreamMetadata(ftl_stream_id_t streamId, StreamMetadata metadata) override;
     void EndStream(ftl_stream_id_t streamId) override;
+    void SendJpegPreviewImage(ftl_stream_id_t streamId, std::vector<uint8_t> jpegData) override;
+
+private:
+    std::string previewSavePath;
+
+    /**
+     * @brief 
+     *  Recursively creates directories for the given path.
+     *  Thanks github.com/JonathonReinhart and http://stackoverflow.com/a/2336245/119527
+     * @param path path to directory to recursively create
+     * @return int 0 on success, -1 on failure
+     */
+    int recursiveMkDir(std::string path);
 };

--- a/FtlExceptions.h
+++ b/FtlExceptions.h
@@ -1,0 +1,34 @@
+/**
+ * @file FtlExceptions.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @brief This file contains definitions for all of the FTL exception classes
+ * @version 0.1
+ * @date 2020-10-16
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#pragma once
+
+#include <stdexcept>
+
+/**
+ * @brief Exception describing a failure with preview generation
+ */
+struct PreviewGenerationFailedException : std::runtime_error
+{
+    PreviewGenerationFailedException(const char* message) throw() : 
+        std::runtime_error(message)
+    { }
+};
+
+/**
+ * @brief Exception describing a failure in communicating to the service connection
+ */
+struct ServiceConnectionCommunicationFailedException : std::runtime_error
+{
+    ServiceConnectionCommunicationFailedException(const char* message) throw() : 
+        std::runtime_error(message)
+    { }
+};

--- a/FtlStream.cpp
+++ b/FtlStream.cpp
@@ -441,7 +441,7 @@ void FtlStream::startStreamMetadataReportingThread()
             {
                 JANUS_LOG(
                     LOG_ERR,
-                    "FTL: Failed to send JPEG preview for stream %d to service connection. Error: %s",
+                    "FTL: Failed to send JPEG preview for stream %d to service connection. Error: %s\n",
                     streamId,
                     e.what());
             }

--- a/FtlStream.cpp
+++ b/FtlStream.cpp
@@ -10,8 +10,10 @@
 
 #include "FtlStream.h"
 #include "JanusSession.h"
-#include <poll.h>
 #include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <poll.h>
 extern "C"
 {
     #include <unistd.h>
@@ -444,7 +446,11 @@ void FtlStream::processKeyframePacket(std::shared_ptr<std::vector<unsigned char>
         // Try to use it to generate a preview!
         if (previewGenerator)
         {
-            previewGenerator->GenerateImage(keyframe);
+            std::vector<uint8_t> jpegImg = previewGenerator->GenerateJpegImage(keyframe);
+            std::ofstream jpegFile;
+            jpegFile.open("test.jpg");
+            jpegFile.write(reinterpret_cast<const char*>(jpegImg.data()), jpegImg.size());
+            jpegFile.close();
         }
     }
 

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -11,6 +11,7 @@
 
 #include "RtpRelayPacket.h"
 #include "FtlTypes.h"
+#include "H264PreviewGenerator.h"
 #include "IngestConnection.h"
 #include "RelayThreadPool.h"
 #include "StreamMetadata.h"
@@ -90,6 +91,7 @@ private:
     bool stopping = false;
     std::map<rtp_payload_type_t, rtp_sequence_num_t> latestSequence;
     std::map<rtp_payload_type_t, std::set<rtp_sequence_num_t>> lostPackets;
+    std::unique_ptr<PreviewGenerator> previewGenerator;
     // Metadata/reporting
     std::time_t streamStartTime;
     std::atomic<uint32_t> currentSourceBitrateBps {0};

--- a/FtlStream.h
+++ b/FtlStream.h
@@ -105,6 +105,7 @@ private:
     Keyframe keyframe;
     Keyframe pendingKeyframe;
     std::set<std::shared_ptr<JanusSession>> keyframeSentToViewers;
+    uint32_t lastKeyframePreviewReported = 0;
 
     /* Private methods */
     void ingestConnectionClosed(IngestConnection& connection);

--- a/GlimeshServiceConnection.cpp
+++ b/GlimeshServiceConnection.cpp
@@ -154,6 +154,13 @@ void GlimeshServiceConnection::EndStream(ftl_stream_id_t streamId)
         }
     }
 }
+
+void GlimeshServiceConnection::SendJpegPreviewImage(
+    ftl_stream_id_t streamId,
+    std::vector<uint8_t> jpegData)
+{
+
+}
 #pragma endregion
 
 #pragma region Private methods

--- a/GlimeshServiceConnection.h
+++ b/GlimeshServiceConnection.h
@@ -45,6 +45,8 @@ public:
 
 private:
     /* Private members */
+    const int MAX_RETRIES = 5;
+    const int TIME_BETWEEN_RETRIES_MS = 3000;
     std::string hostname;
     uint16_t port;
     bool useHttps;
@@ -57,6 +59,7 @@ private:
     /* Private methods */
     httplib::Client getHttpClient();
     void ensureAuth();
-    JsonPtr runGraphQlQuery(std::string query, JsonPtr variables = nullptr);
+    JsonPtr runGraphQlQuery(std::string query, JsonPtr variables = nullptr, httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
+    JsonPtr processGraphQlResponse(httplib::Result result);
     tm parseIso8601DateTime(std::string dateTimeString);
 };

--- a/GlimeshServiceConnection.h
+++ b/GlimeshServiceConnection.h
@@ -41,6 +41,7 @@ public:
     ftl_stream_id_t StartStream(ftl_channel_id_t channelId) override;
     void UpdateStreamMetadata(ftl_stream_id_t streamId, StreamMetadata metadata) override;
     void EndStream(ftl_stream_id_t streamId) override;
+    void SendJpegPreviewImage(ftl_stream_id_t streamId, std::vector<uint8_t> jpegData) override;
 
 private:
     /* Private members */

--- a/H264PreviewGenerator.cpp
+++ b/H264PreviewGenerator.cpp
@@ -9,19 +9,16 @@
  */
 
 #include "H264PreviewGenerator.h"
+#include "FtlExceptions.h"
 #include "Keyframe.h"
 extern "C"
 {
     #include <rtp.h>
-    #include <debug.h>
 }
 
 #pragma region PreviewGenerator
 std::vector<uint8_t> H264PreviewGenerator::GenerateJpegImage(const Keyframe& keyframe)
 {
-    JANUS_LOG(LOG_INFO,
-        "FTL: Decoding %d keyframe packets into frame...\n",
-        keyframe.rtpPackets.size());
     std::vector<char> keyframeDataBuffer;
 
     // We need to shove all of the keyframe NAL units into a buffer to feed into libav
@@ -32,7 +29,7 @@ std::vector<uint8_t> H264PreviewGenerator::GenerateJpegImage(const Keyframe& key
         char* payload = 
             janus_rtp_payload(reinterpret_cast<char*>(packet->data()), packet->size(), &payloadLength);
         
-        if (!payload) // || payloadLength < 6
+        if (!payload || payloadLength < 2)
         {
             // Invalid packet payload
             continue;
@@ -40,17 +37,9 @@ std::vector<uint8_t> H264PreviewGenerator::GenerateJpegImage(const Keyframe& key
 
         // Parse out H264 packet data
         uint8_t fragmentType = *(payload)   & 0b00011111; // 0x1F
-        uint8_t nalType      = *(payload+1) & 0b00011111; // 0x1F
+        // uint8_t nalType      = *(payload+1) & 0b00011111; // 0x1F
         uint8_t startBit     = *(payload+1) & 0b10000000; // 0x80
-        uint8_t endBit       = *(payload+1) & 0b01000000; // 0x40
-
-        JANUS_LOG(LOG_INFO,
-            "FTL: Packet size %d - Fragment %u, NAL: %u, Start: %u, End: %u\n",
-            payloadLength,
-            fragmentType,
-            nalType,
-            startBit,
-            endBit);
+        // uint8_t endBit       = *(payload+1) & 0b01000000; // 0x40
 
         // For fragmented types, start bits are special, they have some extra data in the NAL header
         // that we need to include.
@@ -58,8 +47,6 @@ std::vector<uint8_t> H264PreviewGenerator::GenerateJpegImage(const Keyframe& key
         {
             if (startBit)
             {
-                JANUS_LOG(LOG_INFO, "FTL: START FRAGMENTED NAL\n");
-
                 // Write the start code
                 keyframeDataBuffer.push_back(0x00);
                 keyframeDataBuffer.push_back(0x00);
@@ -78,8 +65,6 @@ std::vector<uint8_t> H264PreviewGenerator::GenerateJpegImage(const Keyframe& key
         }
         else
         {
-            JANUS_LOG(LOG_INFO, "FTL: WRITE SINGLE NAL\n");
-
             // Write the start code
             keyframeDataBuffer.push_back(0x00);
             keyframeDataBuffer.push_back(0x00);
@@ -96,75 +81,69 @@ std::vector<uint8_t> H264PreviewGenerator::GenerateJpegImage(const Keyframe& key
 
     // Decode time
     const AVCodec* codec;
-    AVCodecContext* context = nullptr;
-    AVFrame* frame = av_frame_alloc();
-    AVPacket* packet = av_packet_alloc();
+    AVFramePtr frame(av_frame_alloc());
+    AVPacketPtr packet(av_packet_alloc());
     int ret;
 
     codec = avcodec_find_decoder(AV_CODEC_ID_H264);
     if (!codec)
     {
-        throw std::runtime_error("Could not find H264 codec!");
+        throw PreviewGenerationFailedException("Could not find H264 codec!");
     }
 
-    context = avcodec_alloc_context3(codec);
-    if (!context)
+    AVCodecContextPtr context(avcodec_alloc_context3(codec));
+    if (context.get() == nullptr)
     {
-        throw std::runtime_error("Could not allocate video codec context!");
+        throw PreviewGenerationFailedException("Could not allocate video codec context!");
     }
 
-    if (avcodec_open2(context, codec, nullptr) < 0)
+    if (avcodec_open2(context.get(), codec, nullptr) < 0)
     {
-        throw std::runtime_error("Could not open codec!");
+        throw PreviewGenerationFailedException("Could not open codec!");
     }
 
-    av_init_packet(packet);
+    av_init_packet(packet.get());
     packet->data = reinterpret_cast<uint8_t*>(keyframeDataBuffer.data());
     packet->size = keyframeDataBuffer.size();
     packet->flags |= AV_PKT_FLAG_KEY;
 
     // So let's decode this packet.
-    ret = avcodec_send_packet(context, packet);
+    ret = avcodec_send_packet(context.get(), packet.get());
     if (ret < 0)
     {
-        throw std::runtime_error("Error sending a packet for decoding.");
+        throw PreviewGenerationFailedException("Error sending a packet for decoding.");
     }
 
-    ret = avcodec_receive_frame(context, frame);
+    // Receive the decoded frame
+    ret = avcodec_receive_frame(context.get(), frame.get());
     if (ret < 0)
     {
-        throw std::runtime_error("Error receiving decoded frame.");
+        throw PreviewGenerationFailedException("Error receiving decoded frame.");
     }
-
-    JANUS_LOG(LOG_INFO, "FTL: WE'VE GOT A DECODED FRAME!\n");
 
     // Now encode it to a JPEG
-    std::vector<uint8_t> returnVal = encodeToJpeg(frame);
-
-    // av_frame_free(&frame); // This should be handled by encodeToJpeg
-    avcodec_free_context(&context);
-    av_packet_free(&packet);
+    std::vector<uint8_t> returnVal = encodeToJpeg(std::move(frame));
 
     return returnVal;
 }
 #pragma endregion
 
 #pragma region Private methods
-std::vector<uint8_t> H264PreviewGenerator::encodeToJpeg(AVFrame* frame)
+std::vector<uint8_t> H264PreviewGenerator::encodeToJpeg(AVFramePtr frame)
 {
     int ret;
     const AVCodec* jpegCodec = avcodec_find_encoder(AV_CODEC_ID_MJPEG);
-    AVPacket* jpegPacket = av_packet_alloc();
-    av_init_packet(jpegPacket);
+    AVPacketPtr jpegPacket(av_packet_alloc());
+    av_init_packet(jpegPacket.get());
     if (!jpegCodec)
     {
-        throw std::runtime_error("Could not find mjpeg codec!");
+        throw PreviewGenerationFailedException("Could not find mjpeg codec!");
     }
 
-    AVCodecContext* jpegCodecContext = avcodec_alloc_context3(jpegCodec);
-    if (!jpegCodecContext)
+    AVCodecContextPtr jpegCodecContext(avcodec_alloc_context3(jpegCodec));
+    if (jpegCodecContext.get() == nullptr)
     {
-        throw std::runtime_error("Failed to allocated mjpeg codec context!");
+        throw PreviewGenerationFailedException("Failed to allocated mjpeg codec context!");
     }
 
     jpegCodecContext->pix_fmt       = AV_PIX_FMT_YUVJ420P;
@@ -173,28 +152,25 @@ std::vector<uint8_t> H264PreviewGenerator::encodeToJpeg(AVFrame* frame)
     jpegCodecContext->time_base.num = 1;
     jpegCodecContext->time_base.den = 1000000;
 
-    ret = avcodec_open2(jpegCodecContext, jpegCodec, nullptr);
+    ret = avcodec_open2(jpegCodecContext.get(), jpegCodec, nullptr);
     if (ret < 0)
     {
-        throw std::runtime_error("Couldn't open mjpeg codec!");
+        throw PreviewGenerationFailedException("Couldn't open mjpeg codec!");
     }
 
-    ret = avcodec_send_frame(jpegCodecContext, frame);
+    ret = avcodec_send_frame(jpegCodecContext.get(), frame.get());
     if (ret < 0)
     {
-        throw std::runtime_error("Error sending frame to jpeg codec!");
+        throw PreviewGenerationFailedException("Error sending frame to jpeg codec!");
     }
 
-    ret = avcodec_receive_packet(jpegCodecContext, jpegPacket);
+    ret = avcodec_receive_packet(jpegCodecContext.get(), jpegPacket.get());
     if (ret < 0)
     {
-        throw std::runtime_error("Error receiving jpeg packet!");
+        throw PreviewGenerationFailedException("Error receiving jpeg packet!");
     }
 
     std::vector<uint8_t> returnVal(jpegPacket->data, jpegPacket->data + jpegPacket->size);
-    av_packet_free(&jpegPacket);
-    avcodec_free_context(&jpegCodecContext);
-    
     return returnVal;
 }
 #pragma endregion

--- a/H264PreviewGenerator.cpp
+++ b/H264PreviewGenerator.cpp
@@ -1,0 +1,192 @@
+/**
+ * @file H264PreviewGenerator.cpp
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @version 0.1
+ * @date 2020-10-13
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#include "H264PreviewGenerator.h"
+#include "Keyframe.h"
+extern "C"
+{
+    #include <rtp.h>
+    #include <libavcodec/avcodec.h>
+    #include <debug.h>
+}
+
+#pragma region PreviewGenerator
+void H264PreviewGenerator::GenerateImage(const Keyframe& keyframe)
+{
+    JANUS_LOG(LOG_INFO,
+        "FTL: Decoding %d keyframe packets into frame...\n",
+        keyframe.rtpPackets.size());
+    std::vector<char> keyframeDataBuffer;
+
+    // NALU start code
+    // keyframeDataBuffer.push_back(0x00);
+    // keyframeDataBuffer.push_back(0x00);
+    // keyframeDataBuffer.push_back(0x00);
+    // keyframeDataBuffer.push_back(0x01);
+
+    // We need to shove all of the keyframe NAL units into a buffer to feed into libav
+    for (const auto& packet : keyframe.rtpPackets)
+    {
+        // Grab the payload out of the RTP packet
+        int payloadLength = 0;
+        char* payload = 
+            janus_rtp_payload(reinterpret_cast<char*>(packet->data()), packet->size(), &payloadLength);
+        
+        if (!payload) // || payloadLength < 6
+        {
+            // Invalid packet payload
+            continue;
+        }
+
+        // Parse out H264 packet data
+        uint8_t fragmentType = *(payload)   & 0b00011111; // 0x1F
+        uint8_t nalType      = *(payload+1) & 0b00011111; // 0x1F
+        uint8_t startBit     = *(payload+1) & 0b10000000; // 0x80
+        uint8_t endBit       = *(payload+1) & 0b01000000; // 0x40
+
+        JANUS_LOG(LOG_INFO,
+            "FTL: Packet size %d - Fragment %u, NAL: %u, Start: %u, End: %u\n",
+            payloadLength,
+            fragmentType,
+            nalType,
+            startBit,
+            endBit);
+
+        // For fragmented types, start bits are special, they have some extra data in the NAL header
+        // that we need to include.
+        if ((fragmentType == 28))
+        {
+            if (startBit)
+            {
+                JANUS_LOG(LOG_INFO, "FTL: START FRAGMENTED NAL\n");
+
+                // Write the start code
+                keyframeDataBuffer.push_back(0x00);
+                keyframeDataBuffer.push_back(0x00);
+                keyframeDataBuffer.push_back(0x01);
+
+                // Write the re-constructed header
+                char firstByte = (*payload & 0b11100000) | (*(payload + 1) & 0b00011111);
+                keyframeDataBuffer.push_back(firstByte);
+            }
+
+            // Write the rest of the payload
+            for (int i = 2; i < payloadLength; ++i)
+            {
+                keyframeDataBuffer.push_back(payload[i]);
+            }
+        }
+        else
+        {
+            JANUS_LOG(LOG_INFO, "FTL: WRITE SINGLE NAL\n");
+
+            // Write the start code
+            // keyframeDataBuffer.push_back(0x00);
+            keyframeDataBuffer.push_back(0x00);
+            keyframeDataBuffer.push_back(0x00);
+            keyframeDataBuffer.push_back(0x01);
+
+            // Write the rest of the payload
+            for (int i = 0; i < payloadLength; ++i)
+            {
+                keyframeDataBuffer.push_back(payload[i]);
+            }
+        }
+        
+    }
+
+    // Decode time
+    const AVCodec* codec;
+    // AVCodecParserContext* parser;
+    AVCodecContext* context = nullptr;
+    AVFrame* frame = av_frame_alloc();
+    AVPacket* packet = av_packet_alloc();
+    int ret;
+
+    codec = avcodec_find_decoder(AV_CODEC_ID_H264);
+    if (!codec)
+    {
+        throw std::runtime_error("Could not find H264 codec!");
+    }
+
+    // parser = av_parser_init(codec->id);
+    // if (!parser)
+    // {
+    //     throw std::runtime_error("Could not find H264 parser!");
+    // }
+
+    context = avcodec_alloc_context3(codec);
+    if (!context)
+    {
+        throw std::runtime_error("Could not allocate video codec context!");
+    }
+
+    if (avcodec_open2(context, codec, nullptr) < 0)
+    {
+        throw std::runtime_error("Could not open codec!");
+    }
+
+    // Parse the buffer we've created
+    // NOTE: Maybe we can send this straight to an AVPacket ?
+    // ret = av_parser_parse2(
+    //     parser,
+    //     context,
+    //     &packet->data,
+    //     &packet->size,
+    //     reinterpret_cast<const uint8_t*>(keyframeDataBuffer.data()),
+    //     keyframeDataBuffer.size(),
+    //     AV_NOPTS_VALUE,
+    //     AV_NOPTS_VALUE,
+    //     0);
+    // if (ret < 0)
+    // {
+    //     throw std::runtime_error("Error while parsing.");
+    // }
+
+    // We should see a packet here.
+    // if (packet->size <= 0)
+    // {
+    //     throw std::runtime_error("Expected H264 packet from keyframe, but found none.");
+    // }
+
+    // So let's decode this packet.
+    // ret = avcodec_send_packet(context, packet);
+    // if (ret < 0)
+    // {
+    //     throw std::runtime_error("Error sending a packet for decoding.");
+    // }
+
+    // ret = avcodec_receive_frame(context, frame);
+    // if (ret < 0)
+    // {
+    //     throw std::runtime_error("Error receiving decoded frame.");
+    // }
+
+    av_init_packet(packet);
+    packet->data = reinterpret_cast<uint8_t*>(keyframeDataBuffer.data());
+    packet->size = keyframeDataBuffer.size();
+    packet->flags |= AV_PKT_FLAG_KEY;
+
+    int framefinished = 0;
+    ret = avcodec_decode_video2(context, frame, &framefinished, packet);
+
+    if (framefinished <= 0)
+    {
+        throw std::runtime_error("Error receiving decoded frame.");
+    }
+
+    JANUS_LOG(LOG_INFO, "FTL: WE'VE GOT A DECODED FRAME!\n");
+
+    av_frame_free(&frame);
+    avcodec_free_context(&context);
+    // av_parser_close(parser);
+    av_packet_free(&packet);
+}
+#pragma endregion

--- a/H264PreviewGenerator.h
+++ b/H264PreviewGenerator.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "PreviewGenerator.h"
+#include "LibAvCodecPtr.h"
 
 extern "C"
 {
@@ -30,5 +31,5 @@ public:
     std::vector<uint8_t> GenerateJpegImage(const Keyframe& keyframe) override;
 
 private:
-    std::vector<uint8_t> encodeToJpeg(AVFrame* frame);
+    std::vector<uint8_t> encodeToJpeg(AVFramePtr frame);
 };

--- a/H264PreviewGenerator.h
+++ b/H264PreviewGenerator.h
@@ -1,0 +1,26 @@
+/**
+ * @file H264PreviewGenerator.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @version 0.1
+ * @date 2020-10-13
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#pragma once
+
+#include "PreviewGenerator.h"
+
+/**
+ * @brief
+ *  H264PreviewGenerator is the PreviewGenerator implementation for streams utilizing
+ *  H264 video encoding.
+ */
+class H264PreviewGenerator :
+    public PreviewGenerator
+{
+public:
+    /* PreviewGenerator */
+    void GenerateImage(const Keyframe& keyframe) override;
+};

--- a/H264PreviewGenerator.h
+++ b/H264PreviewGenerator.h
@@ -12,6 +12,11 @@
 
 #include "PreviewGenerator.h"
 
+extern "C"
+{
+    #include <libavcodec/avcodec.h>
+}
+
 /**
  * @brief
  *  H264PreviewGenerator is the PreviewGenerator implementation for streams utilizing
@@ -22,5 +27,8 @@ class H264PreviewGenerator :
 {
 public:
     /* PreviewGenerator */
-    void GenerateImage(const Keyframe& keyframe) override;
+    std::vector<uint8_t> GenerateJpegImage(const Keyframe& keyframe) override;
+
+private:
+    std::vector<uint8_t> encodeToJpeg(AVFrame* frame);
 };

--- a/JanusFtl.cpp
+++ b/JanusFtl.cpp
@@ -267,7 +267,8 @@ void JanusFtl::initServiceConnection()
         break;
     case ServiceConnectionKind::DummyServiceConnection:
     default:
-        serviceConnection = std::make_shared<DummyServiceConnection>();
+        serviceConnection = std::make_shared<DummyServiceConnection>(
+            configuration->GetDummyPreviewImagePath());
         break;
     }
 

--- a/LibAvCodecPtr.h
+++ b/LibAvCodecPtr.h
@@ -1,0 +1,66 @@
+/**
+ * @file LibAvCodecPtr.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @brief RAII smart pointer wrappers for libavcodec pointers
+ * @version 0.1
+ * @date 2020-10-16
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+#pragma once
+
+#include <memory>
+
+extern "C"
+{
+    #include <libavcodec/avcodec.h>
+}
+
+// RAII Pointer for AVCodecContext
+struct AVCodecContextUnref
+{
+    void operator() (AVCodecContext* context)
+    {
+        if (context != nullptr)
+        {
+            avcodec_free_context(&context);
+        }
+    }
+};
+typedef
+    std::unique_ptr<
+        AVCodecContext,
+        AVCodecContextUnref> AVCodecContextPtr;
+
+// RAII Pointer for AVFrame
+struct AVFrameUnref
+{
+    void operator() (AVFrame* frame)
+    {
+        if (frame != nullptr)
+        {
+            av_frame_free(&frame);
+        }
+    }
+};
+typedef
+    std::unique_ptr<
+        AVFrame,
+        AVFrameUnref> AVFramePtr;
+
+// RAII Pointer for AVPacket
+struct AVPacketUnref
+{
+    void operator() (AVPacket* packet)
+    {
+        if (packet != nullptr)
+        {
+            av_packet_free(&packet);
+        }
+    }
+};
+typedef
+    std::unique_ptr<
+        AVPacket,
+        AVPacketUnref> AVPacketPtr;

--- a/PreviewGenerator.h
+++ b/PreviewGenerator.h
@@ -1,0 +1,27 @@
+/**
+ * @file PreviewGenerator.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @version 0.1
+ * @date 2020-10-13
+ * 
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ * 
+ */
+
+#pragma once
+
+struct Keyframe;
+
+/**
+ * @brief 
+ *  PreviewGenerator is a generic interface to generate previews from video streams
+ *  (still images, thumbnails, motion previews eventually...)
+ */
+class PreviewGenerator
+{
+public:
+    virtual ~PreviewGenerator()
+    { }
+
+    virtual void GenerateImage(const Keyframe& keyframe) = 0;
+};

--- a/PreviewGenerator.h
+++ b/PreviewGenerator.h
@@ -10,6 +10,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
 struct Keyframe;
 
 /**
@@ -23,5 +26,5 @@ public:
     virtual ~PreviewGenerator()
     { }
 
-    virtual void GenerateImage(const Keyframe& keyframe) = 0;
+    virtual std::vector<uint8_t> GenerateJpegImage(const Keyframe& keyframe) = 0;
 };

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ First, compile and install [Janus](https://github.com/meetecho/janus-gateway).
 
 Get [Meson](https://mesonbuild.com/Getting-meson.html) for building.
 
+Install `libavcodec` library (`sudo apt install libavcodec-dev` on Ubuntu).
+
 ## Building
 
 By default during build we look for Janus in `/opt/janus` (the default install path), but this can be configured with the `JANUS_PATH` env var.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Configuration is achieved through environment variables.
 | Environment Variable   | Supported Values | Notes             |
 | :--------------------- | :--------------- | :---------------- |
 | `FTL_HOSTNAME`         | Valid hostname   | The hostname of the machine running the FTL service. Defaults to system hostname. |
-| `FTL_SERVICE_CONNECTION` | `DUMMY`: Dummy service connection <br />`GLIMESH`: Glimesh service connection | This configuration value determines which service FTL should plug into for operations such as stream key retrieval. |
+| `FTL_SERVICE_CONNECTION` | `DUMMY`: (default) Dummy service connection <br />`GLIMESH`: Glimesh service connection | This configuration value determines which service FTL should plug into for operations such as stream key retrieval. |
 | `FTL_SERVICE_METADATAREPORTINTERVALMS` | Time in milliseconds | Defaults to `4000`, controls how often FTL stream metadata will be reported to the service. |
+| `FTL_SERVICE_DUMMY_PREVIEWIMAGEPATH` | `/path/to/directory` | The path where preview images of ingested streams will be stored if service connection is `DUMMY`. Defaults to `~/.ftl/previews` |
 | `FTL_SERVICE_GLIMESH_HOSTNAME` | Hostname value (ex. `localhost`, `glimesh.tv`) | This is the hostname the Glimesh service connection will attempt to reach. |
 | `FTL_SERVICE_GLIMESH_PORT` | Port number, `1`-`65535`. | This is the port used to communicate with the Glimesh service via HTTP/HTTPS. |
 | `FTL_SERVICE_GLIMESH_HTTPS` | `0`: Use HTTP <br />`1`: Use HTTPS | Determines whether HTTPS is used to communicate with the Glimesh service. |

--- a/ServiceConnection.h
+++ b/ServiceConnection.h
@@ -14,6 +14,7 @@
 #include "FtlTypes.h"
 
 #include <string>
+#include <vector>
 
 /**
  * @brief
@@ -61,4 +62,11 @@ public:
      * @param streamId ID of stream to end
      */
     virtual void EndStream(ftl_stream_id_t streamId) = 0;
+
+    /**
+     * @brief Sends a JPEG preview image of a stream to the service.
+     * 
+     * @param thumbnailData buffer containing JPEG image data
+     */
+    virtual void SendJpegPreviewImage(ftl_stream_id_t streamId, std::vector<uint8_t> jpegData) = 0;
 };

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ sources = files([
     'FtlStream.cpp',
     'FtlStreamStore.cpp',
     'GlimeshServiceConnection.cpp',
+    'H264PreviewGenerator.cpp',
     'IngestConnection.cpp',
     'IngestServer.cpp',
     'janus_ftl.cpp',

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,8 @@ deps = [
     dependency('libsrtp2'),
     dependency('jansson'),
     dependency('libssl'),
-    dependency('libcrypto')
+    dependency('libcrypto'),
+    dependency('libavcodec')
 ]
 
 incdir = include_directories(


### PR DESCRIPTION
This change adds the `PreviewGenerator` abstraction which represents a class that can generate previews for a given FTL stream. Right now, it exposes just one method, `GenerateJpegImage(Keyframe)`. There is only one implementation of this class, and that is `H264PreviewGenerator` for H264 streams.

`ServiceConnection` has been updated with a new method, `SendJpegPreviewImage(streamId, jpegData)`, meant to transmit the jpeg preview image to the given service connection. The `GlimeshServiceConnection` will transmit the jpeg data to Glimesh via a GraphQL query, whereas the `DummyServiceConnection` will write the jpeg data to a local file in the directory indicated by the `FTL_SERVICE_DUMMY_PREVIEWIMAGEPATH` env var (`~/.ftl/previews` by default).

`FtlExceptions.h` has been added and populated with some exception types to start cleaning up error handling across the project.

`GlimeshServiceConnection` now has retry logic when an http request fails, throwing if the maximum number of retries is exceeded (currently 5).