### PR TITLE
🔐 Add env override for dummy hmac key

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -61,6 +61,12 @@ void Configuration::Load()
         serviceConnectionMetadataReportIntervalMs = std::stoi(varVal);
     }
 
+    // FTL_SERVICE_DUMMY_HMAC_KEY -> DummyHmacKey
+    if (char* varVal = std::getenv("FTL_SERVICE_DUMMY_HMAC_KEY"))
+    {
+        dummyHmacKey = std::string(varVal);
+    }
+
     // FTL_SERVICE_DUMMY_PREVIEWIMAGEPATH -> DummyPreviewImagePath
     if (char* varVal = std::getenv("FTL_SERVICE_DUMMY_PREVIEWIMAGEPATH"))
     {
@@ -112,6 +118,11 @@ std::string Configuration::GetMyHostname()
 ServiceConnectionKind Configuration::GetServiceConnectionKind()
 {
     return serviceConnectionKind;
+}
+
+std::string Configuration::GetDummyHmacKey()
+{
+    return dummyHmacKey;
 }
 
 std::string Configuration::GetDummyPreviewImagePath()

--- a/Configuration.h
+++ b/Configuration.h
@@ -29,7 +29,11 @@ public:
     std::string GetMyHostname();
     ServiceConnectionKind GetServiceConnectionKind();
     uint16_t GetServiceConnectionMetadataReportIntervalMs();
+
+    // Dummy Service Connection Values
+    std::string GetDummyHmacKey();
     std::string GetDummyPreviewImagePath();
+
     // Glimesh Service Connection Values
     std::string GetGlimeshServiceHostname();
     uint16_t GetGlimeshServicePort();
@@ -42,7 +46,11 @@ private:
     std::string myHostname;
     ServiceConnectionKind serviceConnectionKind = ServiceConnectionKind::DummyServiceConnection;
     uint16_t serviceConnectionMetadataReportIntervalMs = 4000;
+
+    // Dummy Service Connection Backing Stores
+    std::string dummyHmacKey = "aBcDeFgHiJkLmNoPqRsTuVwXyZ123456";
     std::string dummyPreviewImagePath;
+
     // Glimesh Service Connection Backing Stores
     std::string glimeshServiceHostname = "localhost";
     uint16_t glimeshServicePort = 4000;

--- a/DummyServiceConnection.cpp
+++ b/DummyServiceConnection.cpp
@@ -19,7 +19,8 @@
 #include <stdexcept>
 
 #pragma region Constructor/Destructor
-DummyServiceConnection::DummyServiceConnection(std::string previewSavePath) : 
+DummyServiceConnection::DummyServiceConnection(std::string hmacKey, std::string previewSavePath) : 
+    hmacKey(hmacKey),
     previewSavePath(previewSavePath)
 { }
 #pragma endregion
@@ -38,7 +39,7 @@ void DummyServiceConnection::Init()
 
 std::string DummyServiceConnection::GetHmacKey(ftl_channel_id_t channelId)
 {
-    return "aBcDeFgHiJkLmNoPqRsTuVwXyZ123456";
+    return this->hmacKey;
 }
 
 ftl_stream_id_t DummyServiceConnection::StartStream(ftl_channel_id_t channelId)

--- a/DummyServiceConnection.h
+++ b/DummyServiceConnection.h
@@ -24,7 +24,7 @@ class DummyServiceConnection :
 {
 public:
     /* Constructor/Destructor */
-    DummyServiceConnection(std::string previewSavePath);
+    DummyServiceConnection(std::string hmacKey, std::string previewSavePath);
 
     // ServiceConnection
     void Init() override;
@@ -35,6 +35,7 @@ public:
     void SendJpegPreviewImage(ftl_stream_id_t streamId, std::vector<uint8_t> jpegData) override;
 
 private:
+    std::string hmacKey;
     std::string previewSavePath;
 
     /**

--- a/JanusFtl.cpp
+++ b/JanusFtl.cpp
@@ -268,6 +268,7 @@ void JanusFtl::initServiceConnection()
     case ServiceConnectionKind::DummyServiceConnection:
     default:
         serviceConnection = std::make_shared<DummyServiceConnection>(
+            configuration->GetDummyHmacKey(),
             configuration->GetDummyPreviewImagePath());
         break;
     }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The default stream key is `123456789-aBcDeFgHiJkLmNoPqRsTuVwXyZ123456`.
 
 `123456789` can be whatever "Channel ID" you'd like.
 
+`aBcDeFgHiJkLmNoPqRsTuVwXyZ123456` can be overridden by setting the `FTL_SERVICE_DUMMY_HMAC_KEY` environment variable.
+
 See `DummyServiceConnection.cpp` for the default stream key retrieval mechanism.
 
 For watching your stream from a browser, see [janus-ftl-player](https://github.com/Glimesh/janus-ftl-player).
@@ -65,6 +67,7 @@ Configuration is achieved through environment variables.
 | `FTL_HOSTNAME`         | Valid hostname   | The hostname of the machine running the FTL service. Defaults to system hostname. |
 | `FTL_SERVICE_CONNECTION` | `DUMMY`: (default) Dummy service connection <br />`GLIMESH`: Glimesh service connection | This configuration value determines which service FTL should plug into for operations such as stream key retrieval. |
 | `FTL_SERVICE_METADATAREPORTINTERVALMS` | Time in milliseconds | Defaults to `4000`, controls how often FTL stream metadata will be reported to the service. |
+| `FTL_SERVICE_DUMMY_HMAC_KEY` | String, default: `aBcDeFgHiJkLmNoPqRsTuVwXyZ123456` | Key all FTL clients must use if service connection is `DUMMY`. The HMAC key is the part after the dash in a stream key.` |
 | `FTL_SERVICE_DUMMY_PREVIEWIMAGEPATH` | `/path/to/directory` | The path where preview images of ingested streams will be stored if service connection is `DUMMY`. Defaults to `~/.ftl/previews` |
 | `FTL_SERVICE_GLIMESH_HOSTNAME` | Hostname value (ex. `localhost`, `glimesh.tv`) | This is the hostname the Glimesh service connection will attempt to reach. |
 | `FTL_SERVICE_GLIMESH_PORT` | Port number, `1`-`65535`. | This is the port used to communicate with the Glimesh service via HTTP/HTTPS. |


### PR DESCRIPTION
Currently when using the dummy service connection the hmac key is hard coded as `aBcDeFgHiJkLmNoPqRsTuVwXyZ123456`.

This change

Changes:
- Allow overriding the key with the environment variable `FTL_SERVICE_DUMMY_HMAC_KEY` so local testing can both be more realistic and more secure
- Update README documentation of the new env variable