### PR TITLE
⬆️ Update base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get -y install curl libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build libavcodec-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install curl libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build libavcodec-dev
 
 RUN pip3 install meson
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get -y install curl libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build libavcodec-dev
 

--- a/FtlStream.cpp
+++ b/FtlStream.cpp
@@ -433,7 +433,7 @@ void FtlStream::startStreamMetadataReportingThread()
             {
                 JANUS_LOG(
                     LOG_ERR,
-                    "FTL: Failed to generate JPEG preview for stream %d, error: %s",
+                    "FTL: Failed to generate JPEG preview for stream %d. Error: %s\n",
                     streamId,
                     e.what());
             }


### PR DESCRIPTION
Always nice to upgrade to the latest Ubuntu LTS, and at least for me this makes the H264 decoder work in the Docker image.

Previously I would continuously see the following printed:
```
[ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [../FtlStream.cpp:startStreamMetadataReportingThread:438] FTL: Failed to generate JPEG preview for stream 1, error: Could not find H264 codec![ERR] [ice.c:janus_ice_outgoing_stats_handle:4047] [7941889442352283] Got 85 SRTP/SRTCP errors in the last few seconds (last error: srtp_err_status_replay_old)
```
I also went ahead and added a newline to he log per convention to make this error print nicer.