### PR TITLE
🛑 Properly close connections

### DIFF
--- a/IngestConnection.cpp
+++ b/IngestConnection.cpp
@@ -43,7 +43,7 @@ void IngestConnection::Start()
 void IngestConnection::Stop()
 {
     // TODO: Try to tell the client nicely that we're outta here
-    shutdown(connectionHandle, SHUT_RDWR);
+    close(connectionHandle);
 }
 
 sockaddr_in IngestConnection::GetAcceptAddress()

--- a/IngestServer.cpp
+++ b/IngestServer.cpp
@@ -81,6 +81,7 @@ void IngestServer::Stop()
     pendingConnections.clear();
     shutdown(listenSocketHandle, SHUT_RDWR);
     listenThread.join();
+    close(listenSocketHandle);
 }
 
 void IngestServer::SetOnRequestMediaConnection(


### PR DESCRIPTION
Fixes #18

Tested locally by connecting/disconnecting multiple clients while also starting/stopping streaming.

Verified via `ls -l /proc/{pid}/fd` that the number of open file descriptors does not keep growing and growing with this change.