### PR TITLE
🚦 Allow relaying of FTL streams via Orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ test/test
 core
 build/
 builddir/
+subprojects/*
+!subprojects/*.wrap

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp-httplib"]
 	path = cpp-httplib
 	url = https://github.com/yhirose/cpp-httplib
+[submodule "janus-ftl-orchestrator"]
+	path = janus-ftl-orchestrator
+	url = git@github.com:Glimesh/janus-ftl-orchestrator.git

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Configuration is achieved through environment variables.
 | `FTL_ORCHESTRATOR_HOSTNAME` | Valid hostname | The hostname of the Orchestrator service to connect to for stream relay information. |
 | `FTL_ORCHESTRATOR_PORT` | Port number, `1`-`65535`. | The port number to use when connecting to the Orchestrator service. |
 | `FTL_ORCHESTRATOR_PSK` | String of arbitrary hex values (ex. `001122334455ff`) | This is the pre-shared key used to establish a secure TLS1.3 connection to the Orchestrator service. |
+| `FTL_ORCHESTRATOR_REGION_CODE` | String value, default: `global` | This is a string value used by the Orchestrator to group regional nodes together to more effectively distribute video traffic. |
 | `FTL_SERVICE_CONNECTION` | `DUMMY`: (default) Dummy service connection <br />`GLIMESH`: Glimesh service connection | This configuration value determines which service FTL should plug into for operations such as stream key retrieval. |
 | `FTL_SERVICE_METADATAREPORTINTERVALMS` | Time in milliseconds | Defaults to `4000`, controls how often FTL stream metadata will be reported to the service. |
 | `FTL_SERVICE_DUMMY_HMAC_KEY` | String, default: `aBcDeFgHiJkLmNoPqRsTuVwXyZ123456` | Key all FTL clients must use if service connection is `DUMMY`. The HMAC key is the part after the dash in a stream key.` |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Configuration is achieved through environment variables.
 | Environment Variable   | Supported Values | Notes             |
 | :--------------------- | :--------------- | :---------------- |
 | `FTL_HOSTNAME`         | Valid hostname   | The hostname of the machine running the FTL service. Defaults to system hostname. |
+| `FTL_NODE_KIND`        | `Standalone`: (default) This instance will listen for incoming FTL connections and transmit them to WebRTC clients.<br />`Ingest`: This instance will listen for incoming FTL connections and relay them to other nodes when instructed by an Orchestrator service.<br />`Edge`: This instance will receive stream relays from other nodes and transmit them to WebRTC clients. | This configuration value controls the behavior of the FTL plugin when used in conjunction with an [Orchestrator service](https://github.com/Glimesh/janus-ftl-orchestrator). |
+| `FTL_ORCHESTRATOR_HOSTNAME` | Valid hostname | The hostname of the Orchestrator service to connect to for stream relay information. |
+| `FTL_ORCHESTRATOR_PORT` | Port number, `1`-`65535`. | The port number to use when connecting to the Orchestrator service. |
+| `FTL_ORCHESTRATOR_PSK` | String of arbitrary hex values (ex. `001122334455ff`) | This is the pre-shared key used to establish a secure TLS1.3 connection to the Orchestrator service. |
 | `FTL_SERVICE_CONNECTION` | `DUMMY`: (default) Dummy service connection <br />`GLIMESH`: Glimesh service connection | This configuration value determines which service FTL should plug into for operations such as stream key retrieval. |
 | `FTL_SERVICE_METADATAREPORTINTERVALMS` | Time in milliseconds | Defaults to `4000`, controls how often FTL stream metadata will be reported to the service. |
 | `FTL_SERVICE_DUMMY_HMAC_KEY` | String, default: `aBcDeFgHiJkLmNoPqRsTuVwXyZ123456` | Key all FTL clients must use if service connection is `DUMMY`. The HMAC key is the part after the dash in a stream key.` |

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ installdir = get_variable('INSTALL_PATH', (januspath + '/lib/janus/plugins'))
 sources = files([
     'src/Configuration.cpp',
     'src/DummyServiceConnection.cpp',
+    'src/FtlClient.cpp',
     'src/FtlStream.cpp',
     'src/FtlStreamStore.cpp',
     'src/GlimeshServiceConnection.cpp',

--- a/meson.build
+++ b/meson.build
@@ -43,8 +43,9 @@ deps = [
     dependency('libssl'),
     dependency('libcrypto'),
     dependency('libavcodec'),
-    subproject('spdlog').get_variable('spdlog_dep'), # use wrapped copy of spdlog
-    subproject('fmt').get_variable('fmt_dep'), # use wrapped copy of fmt
+    # Meson wrapped dependencies
+    subproject('spdlog').get_variable('spdlog_dep'),
+    subproject('fmt', default_options: 'default_library=static').get_variable('fmt_dep'),
 ]
 
 incdir = include_directories(

--- a/meson.build
+++ b/meson.build
@@ -62,3 +62,10 @@ shared_library(
     install: true,
     install_dir: installdir
 )
+
+executable(
+    'ftlclienttest',
+    files(['src/ftlclienttest.cpp', 'src/FtlClient.cpp']),
+    dependencies: deps,
+    include_directories: incdir
+)

--- a/meson.build
+++ b/meson.build
@@ -46,8 +46,8 @@ deps = [
     dependency('libcrypto'),
     dependency('libavcodec'),
     # Meson wrapped dependencies
-    subproject('spdlog').get_variable('spdlog_dep'),
     subproject('fmt', default_options: 'default_library=static').get_variable('fmt_dep'),
+    subproject('spdlog', default_options: 'external_fmt=true').get_variable('spdlog_dep'),
 ]
 
 incdir = include_directories(

--- a/meson.build
+++ b/meson.build
@@ -41,12 +41,14 @@ deps = [
     dependency('jansson'),
     dependency('libssl'),
     dependency('libcrypto'),
-    dependency('libavcodec')
+    dependency('libavcodec'),
+    subproject('spdlog').get_variable('spdlog_dep'), # use wrapped copy of spdlog
 ]
 
 incdir = include_directories(
     './src',
     './cpp-httplib',
+    './janus-ftl-orchestrator/inc',
     janusincludepath,
 )
 

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ project(
         'b_lundef=false', # Don't fail over undefined references, since we refer to some Janus code
         'b_asneeded=false', # Don't exclude libraries if we don't reference them directly
         'werror=true', # treat warnings as errors
+        'default_library=static',
     ],
 )
 
@@ -23,6 +24,7 @@ installdir = get_variable('INSTALL_PATH', (januspath + '/lib/janus/plugins'))
 sources = files([
     'src/Configuration.cpp',
     'src/DummyServiceConnection.cpp',
+    'src/EdgeNodeServiceConnection.cpp',
     'src/FtlClient.cpp',
     'src/FtlStream.cpp',
     'src/FtlStreamStore.cpp',

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,7 @@ deps = [
     dependency('libcrypto'),
     dependency('libavcodec'),
     subproject('spdlog').get_variable('spdlog_dep'), # use wrapped copy of spdlog
+    subproject('fmt').get_variable('fmt_dep'), # use wrapped copy of fmt
 ]
 
 incdir = include_directories(

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -86,6 +86,12 @@ void Configuration::Load()
         orchestratorPsk = hexStringToByteArray(std::string(varVal));
     }
 
+    // FTL_ORCHESTRATOR_REGION_CODE -> OrchestratorRegionCode
+    if (char* varVal = std::getenv("FTL_ORCHESTRATOR_REGION_CODE"))
+    {
+        orchestratorRegionCode = std::string(varVal);
+    }
+
     // FTL_SERVICE_CONNECTION -> ServiceConnectionKind
     if (char* serviceConnectionEnv = std::getenv("FTL_SERVICE_CONNECTION"))
     {
@@ -183,6 +189,11 @@ uint16_t Configuration::GetOrchestratorPort()
 std::vector<std::byte> Configuration::GetOrchestratorPsk()
 {
     return orchestratorPsk;
+}
+
+std::string Configuration::GetOrchestratorRegionCode()
+{
+    return orchestratorRegionCode;
 }
 
 ServiceConnectionKind Configuration::GetServiceConnectionKind()

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -12,6 +12,15 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
+
+enum class NodeKind
+{
+    Standalone = 0,
+    Ingest = 1,
+    // Relay = 2,
+    Edge = 3,
+};
 
 enum class ServiceConnectionKind
 {
@@ -27,6 +36,10 @@ public:
 
     /* Configuration values */
     std::string GetMyHostname();
+    NodeKind GetNodeKind();
+    std::string GetOrchestratorHostname();
+    uint16_t GetOrchestratorPort();
+    std::vector<std::byte> GetOrchestratorPsk();
     ServiceConnectionKind GetServiceConnectionKind();
     uint16_t GetServiceConnectionMetadataReportIntervalMs();
 
@@ -44,6 +57,10 @@ public:
 private:
     /* Backing stores */
     std::string myHostname;
+    NodeKind nodeKind = NodeKind::Standalone;
+    std::string orchestratorHostname;
+    uint16_t orchestratorPort = 8085;
+    std::vector<std::byte> orchestratorPsk;
     ServiceConnectionKind serviceConnectionKind = ServiceConnectionKind::DummyServiceConnection;
     uint16_t serviceConnectionMetadataReportIntervalMs = 4000;
 
@@ -57,4 +74,10 @@ private:
     bool glimeshServiceUseHttps = false;
     std::string glimeshServiceClientId;
     std::string glimeshServiceClientSecret;
+
+    /* Private methods */
+    /**
+     * @brief Takes a hex string of format "010203FF" and converts it to an array of bytes.
+     */
+    std::vector<std::byte> hexStringToByteArray(std::string hexString);
 };

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -40,6 +40,7 @@ public:
     std::string GetOrchestratorHostname();
     uint16_t GetOrchestratorPort();
     std::vector<std::byte> GetOrchestratorPsk();
+    std::string GetOrchestratorRegionCode();
     ServiceConnectionKind GetServiceConnectionKind();
     uint16_t GetServiceConnectionMetadataReportIntervalMs();
 
@@ -61,6 +62,7 @@ private:
     std::string orchestratorHostname;
     uint16_t orchestratorPort = 8085;
     std::vector<std::byte> orchestratorPsk;
+    std::string orchestratorRegionCode = "global";
     ServiceConnectionKind serviceConnectionKind = ServiceConnectionKind::DummyServiceConnection;
     uint16_t serviceConnectionMetadataReportIntervalMs = 4000;
 

--- a/src/DummyServiceConnection.cpp
+++ b/src/DummyServiceConnection.cpp
@@ -44,7 +44,7 @@ std::string DummyServiceConnection::GetHmacKey(ftl_channel_id_t channelId)
 
 ftl_stream_id_t DummyServiceConnection::StartStream(ftl_channel_id_t channelId)
 {
-    return channelId;
+    return currentStreamId++;
 }
 
 void DummyServiceConnection::UpdateStreamMetadata(ftl_stream_id_t streamId, StreamMetadata metadata)

--- a/src/DummyServiceConnection.h
+++ b/src/DummyServiceConnection.h
@@ -37,6 +37,7 @@ public:
 private:
     std::string hmacKey;
     std::string previewSavePath;
+    ftl_stream_id_t currentStreamId = 0;
 
     /**
      * @brief 

--- a/src/EdgeNodeServiceConnection.cpp
+++ b/src/EdgeNodeServiceConnection.cpp
@@ -7,6 +7,10 @@
 
 #include "EdgeNodeServiceConnection.h"
 
+#include "Util.h"
+
+#include <algorithm>
+
 #pragma region Constructor/Destructor
 EdgeNodeServiceConnection::EdgeNodeServiceConnection()
 { }
@@ -15,23 +19,41 @@ EdgeNodeServiceConnection::EdgeNodeServiceConnection()
 #pragma region Public methods
 std::vector<std::byte> EdgeNodeServiceConnection::ProvisionStreamKey(ftl_channel_id_t channelId)
 {
-    return std::vector<std::byte>();
+    // If a stream key already exists for the given channel, just return the existing one
+    if (streamKeys.count(channelId) > 0)
+    {
+        return streamKeys[channelId];
+    }
+    std::vector<std::byte> newKey = Util::GenerateRandomBinaryPayload(streamKeySize);
+    streamKeys[channelId] = newKey;
+    return newKey;
 }
 
 void EdgeNodeServiceConnection::ClearStreamKey(ftl_channel_id_t channelId)
 {
-
+    streamKeys.erase(channelId);
 }
 #pragma endregion Public methods
 
 #pragma region ServiceConnection
 void EdgeNodeServiceConnection::Init()
-{
-
-}
+{ }
 
 std::string EdgeNodeServiceConnection::GetHmacKey(ftl_channel_id_t channelId)
 {
+    if (streamKeys.count(channelId) > 0)
+    {
+        const auto& key = streamKeys[channelId];
+        std::string returnVal;
+        returnVal.reserve(key.size());
+        std::transform(
+            key.begin(),
+            key.end(),
+            std::back_inserter(returnVal),
+            [](std::byte b) { return static_cast<char>(b); });
+
+        return returnVal;
+    }
     return "";
 }
 
@@ -43,20 +65,14 @@ ftl_stream_id_t EdgeNodeServiceConnection::StartStream(ftl_channel_id_t channelI
 void EdgeNodeServiceConnection::UpdateStreamMetadata(
     ftl_stream_id_t streamId,
     StreamMetadata metadata)
-{
-
-}
+{ }
 
 void EdgeNodeServiceConnection::EndStream(
     ftl_stream_id_t streamId)
-{
-
-}
+{ }
 
 void EdgeNodeServiceConnection::SendJpegPreviewImage(
     ftl_stream_id_t streamId,
     std::vector<uint8_t> jpegData)
-{
-
-}
+{ }
 #pragma endregion ServiceConnection

--- a/src/EdgeNodeServiceConnection.cpp
+++ b/src/EdgeNodeServiceConnection.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file EdgeNodeServiceConnection.cpp
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2020-12-18
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ */
+
+#include "EdgeNodeServiceConnection.h"
+
+#pragma region Constructor/Destructor
+EdgeNodeServiceConnection::EdgeNodeServiceConnection()
+{ }
+#pragma endregion Constructor/Destructor
+
+#pragma region Public methods
+std::vector<std::byte> EdgeNodeServiceConnection::ProvisionStreamKey(ftl_channel_id_t channelId)
+{
+    return std::vector<std::byte>();
+}
+
+void EdgeNodeServiceConnection::ClearStreamKey(ftl_channel_id_t channelId)
+{
+
+}
+#pragma endregion Public methods
+
+#pragma region ServiceConnection
+void EdgeNodeServiceConnection::Init()
+{
+
+}
+
+std::string EdgeNodeServiceConnection::GetHmacKey(ftl_channel_id_t channelId)
+{
+    return "";
+}
+
+ftl_stream_id_t EdgeNodeServiceConnection::StartStream(ftl_channel_id_t channelId)
+{
+    return 0;
+}
+
+void EdgeNodeServiceConnection::UpdateStreamMetadata(
+    ftl_stream_id_t streamId,
+    StreamMetadata metadata)
+{
+
+}
+
+void EdgeNodeServiceConnection::EndStream(
+    ftl_stream_id_t streamId)
+{
+
+}
+
+void EdgeNodeServiceConnection::SendJpegPreviewImage(
+    ftl_stream_id_t streamId,
+    std::vector<uint8_t> jpegData)
+{
+
+}
+#pragma endregion ServiceConnection

--- a/src/EdgeNodeServiceConnection.h
+++ b/src/EdgeNodeServiceConnection.h
@@ -43,5 +43,10 @@ public:
     void SendJpegPreviewImage(ftl_stream_id_t streamId, std::vector<uint8_t> jpegData) override;
 
 private:
+    /* Static private members */
+    static constexpr size_t DEFAULT_KEY_SIZE = 32;
+
+    /* Static members */
+    size_t streamKeySize = DEFAULT_KEY_SIZE;
     std::unordered_map<ftl_channel_id_t, std::vector<std::byte>> streamKeys;
 };

--- a/src/EdgeNodeServiceConnection.h
+++ b/src/EdgeNodeServiceConnection.h
@@ -1,0 +1,47 @@
+/**
+ * @file EdgeNodeServiceConnection.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2020-12-18
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ */
+
+#pragma once
+
+#include "ServiceConnection.h"
+
+#include <unordered_map>
+
+/**
+ * @brief
+ *  A virtual service connection meant for edge nodes that serve as relays for existing streams.
+ *  The EdgeNodeServiceConnection will generate and maintain dynamic stream keys for relaying.
+ *  The ingest node is responsible for reporting stream information to an actual service.
+ */
+class EdgeNodeServiceConnection : public ServiceConnection
+{
+public:
+    /* Constructor/Destructor */
+    EdgeNodeServiceConnection();
+
+    /* Public methods */
+    /**
+     * @brief Generates and stores a temporary stream key for the given channel.
+     */
+    std::vector<std::byte> ProvisionStreamKey(ftl_channel_id_t channelId);
+
+    /**
+     * @brief Clears stored temporary stream key for the given channel.
+     */
+    void ClearStreamKey(ftl_channel_id_t channelId);
+
+    /* ServiceConnection */
+    void Init() override;
+    std::string GetHmacKey(ftl_channel_id_t channelId) override;
+    ftl_stream_id_t StartStream(ftl_channel_id_t channelId) override;
+    void UpdateStreamMetadata(ftl_stream_id_t streamId, StreamMetadata metadata) override;
+    void EndStream(ftl_stream_id_t streamId) override;
+    void SendJpegPreviewImage(ftl_stream_id_t streamId, std::vector<uint8_t> jpegData) override;
+
+private:
+    std::unordered_map<ftl_channel_id_t, std::vector<std::byte>> streamKeys;
+};

--- a/src/FtlClient.cpp
+++ b/src/FtlClient.cpp
@@ -7,9 +7,16 @@
 
 #include "FtlClient.h"
 
+#include "Util.h"
+
+#include <fmt/core.h>
 #include <netdb.h>
+#include <openssl/hmac.h>
+#include <regex>
+#include <stdexcept>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #pragma region Constructor/Destructor
 FtlClient::FtlClient(
@@ -23,7 +30,7 @@ FtlClient::FtlClient(
 #pragma endregion Constructor/Destructor
 
 #pragma region Public methods
-Result<void> FtlClient::ConnectAsync()
+Result<void> FtlClient::ConnectAsync(FtlClient::ConnectMetadata metadata)
 {
     // Look up hostname
     addrinfo addrHints { 0 };
@@ -45,26 +52,114 @@ Result<void> FtlClient::ConnectAsync()
     // Attempt to open TCP connection
     // TODO: Loop through additional addresses on failure. For now, only try the first one.
     addrinfo targetAddr = *addrLookup;
-    int socketHandle = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    int connectErr = connect(socketHandle, targetAddr.ai_addr, targetAddr.ai_addrlen);
+    controlSocketHandle = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    int connectErr = connect(controlSocketHandle, targetAddr.ai_addr, targetAddr.ai_addrlen);
     if (connectErr != 0)
     {
+        close(controlSocketHandle);
         freeaddrinfo(addrLookup);
         return Result<void>::Error("Could not connect to Orchestration service on given host");
     }
 
     freeaddrinfo(addrLookup);
 
-    // We provide the thread with a promise that it will fulfill once the connection
-    // is ready. We block until this promise is fulfilled.
-    std::promise<void> connectionReadyPromise;
-    std::future<void> connectionReadyFuture = connectionReadyPromise.get_future();
-    connectionThread = std::thread(
-        &FtlClient::connectionThreadBody,
-        this,
-        std::move(connectionReadyPromise));
+    // Start a new thread to read incoming data
+    connectionThread = std::thread(&FtlClient::connectionThreadBody, this);
     connectionThread.detach();
-    connectionReadyFuture.get();
+
+    // Request HMAC payload and wait for response
+    sendControlMessage("HMAC\r\n\r\n");
+    Result<FtlClient::FtlResponse> hmacResponse = waitForResponse();
+    if (hmacResponse.IsError)
+    {
+        Stop();
+        return Result<void>::Error("Did not receive response to HMAC payload request.");
+    }
+    std::string hmacPayload = hmacResponse.Value.payload;
+
+    // Hash payload against stream key
+    std::byte buffer[512];
+    uint32_t bufferLength;
+    HMAC(
+        EVP_sha512(),
+        streamKey.data(),
+        streamKey.size(),
+        reinterpret_cast<const unsigned char*>(hmacPayload.c_str()),
+        hmacPayload.size(),
+        reinterpret_cast<unsigned char*>(buffer),
+        &bufferLength);
+
+    // Convert hash to string
+    std::string hashString = Util::ByteArrayToHexString(&buffer[0], bufferLength);
+
+    // Send authenticated HMAC request
+    // format: `CONNECT %d $%s\r\n\r\n` (%d = channelId, %s = hmac hash hex)
+    sendControlMessage(fmt::format("CONNECT {} ${}\r\n\r\n", channelId, hashString));
+    Result<FtlClient::FtlResponse> authResponse = waitForResponse();
+    if (authResponse.IsError)
+    {
+        Stop();
+        return Result<void>::Error("Did not receive successful response to HMAC authentication.");
+    }
+    if (authResponse.Value.statusCode != 200)
+    {
+        Stop();
+        return Result<void>::Error("Received error in response to HMAC authentication.");
+    }
+
+    // Now let's send all of our metadata.
+    sendControlMessage(fmt::format(
+        "ProtocolVersion: {}.{}\r\n\r\n",
+        FTL_PROTOCOL_VERSION_MAJOR,
+        FTL_PROTOCOL_VERSION_MINOR));
+    sendControlMessage(fmt::format("VendorName: {}\r\n\r\n", metadata.VendorName));
+    sendControlMessage(fmt::format("VendorVersion: {}\r\n\r\n", metadata.VendorVersion));
+    sendControlMessage(fmt::format("Video: {}\r\n\r\n", metadata.HasVideo ? "true" : "false"));
+    sendControlMessage(fmt::format("VideoCodec: {}\r\n\r\n", metadata.VideoCodec));
+    sendControlMessage(fmt::format("VideoHeight: {}\r\n\r\n", metadata.VideoHeight));
+    sendControlMessage(fmt::format("VideoWidth: {}\r\n\r\n", metadata.VideoWidth));
+    sendControlMessage(fmt::format("VideoPayloadType: {}\r\n\r\n", metadata.VideoPayloadType));
+    sendControlMessage(fmt::format("VideoIngestSSRC: {}\r\n\r\n", metadata.VideoIngestSsrc));
+    sendControlMessage(fmt::format("Audio: {}\r\n\r\n", metadata.HasAudio ? "true" : "false"));
+    sendControlMessage(fmt::format("AudioCodec: {}\r\n\r\n", metadata.AudioCodec));
+    sendControlMessage(fmt::format("AudioPayloadType: {}\r\n\r\n", metadata.AudioPayloadType));
+    sendControlMessage(fmt::format("AudioIngestSSRC: {}\r\n\r\n", metadata.AudioIngestSsrc));
+
+    // Indicate that we are done providing metadata and wait for a response.
+    sendControlMessage(".\r\n\r\n");
+    Result<FtlClient::FtlResponse> metadataResponse = waitForResponse();
+    if (metadataResponse.IsError)
+    {
+        Stop();
+        return Result<void>::Error("Didn't receive a response after providing stream metadata.");
+    }
+
+    // Attempt to parse the port assignment out of the response payload
+    std::regex portPattern = std::regex(R"~(Use UDP port ([0-9]+))~", std::regex_constants::icase);
+    std::smatch portPatternMatch;
+    if (!std::regex_match(metadataResponse.Value.payload, portPatternMatch, portPattern) ||
+        (portPatternMatch.size() < 2))
+    {
+        Stop();
+        return Result<void>::Error("Expected a UDP port assignment but didn't receive one.");
+    }
+    try
+    {
+        int parsedPort = std::stoi(portPatternMatch[1].str());
+        if ((parsedPort < 0) || (parsedPort > UINT16_MAX))
+        {
+            Stop();
+            return Result<void>::Error("Invalid UDP port assignment.");
+        }
+        assignedMediaPort = static_cast<uint16_t>(parsedPort);
+    }
+    catch (...)
+    {
+        Stop();
+        return Result<void>::Error("Invalid UDP port assignment.");
+    }
+
+    // TODO: Open UDP connection to assigned UDP port
 
     return Result<void>::Success();
 }
@@ -76,8 +171,111 @@ void FtlClient::SetOnClosed(std::function<void()> onClosed)
 #pragma endregion Public methods
 
 #pragma region Private methods
-void FtlClient::connectionThreadBody(std::promise<void>&& connectionReadyPromise)
+void FtlClient::connectionThreadBody()
 {
-    connectionReadyPromise.set_value();
+    std::string receivedBytes;
+    char recvBuffer[512] = {0};
+    int readBytes = 0;
+
+    while (true)
+    {
+        readBytes = read(controlSocketHandle, recvBuffer, sizeof(recvBuffer));
+
+        if (readBytes < 0)
+        {
+            // TODO: We're closing or something went wrong
+            break;
+        }
+
+        receivedBytes.insert(receivedBytes.end(), recvBuffer, (recvBuffer + readBytes));
+        size_t requestEndPosition = 
+            receivedBytes.find("\n", (receivedBytes.size() - readBytes), readBytes);
+        if (requestEndPosition != std::string::npos)
+        {
+            // Pull out the request
+            std::string requestStr(
+                receivedBytes.begin(),
+                (receivedBytes.begin() + requestEndPosition));
+            receivedBytes.erase(
+                receivedBytes.begin(),
+                (receivedBytes.begin() + requestEndPosition));
+
+            // We expect at least a status code plus newline character
+            if (requestStr.size() < 4)
+            {
+                // TODO: bad request.
+                break;
+            }
+
+            // Parse the status code (3 digits)
+            uint16_t statusCode = 0;
+            try
+            {
+                int statusCodeInt = 
+                    std::stoi(std::string(requestStr.begin(), requestStr.begin() + 3));
+                if ((statusCodeInt >= 0) && (statusCodeInt < UINT16_MAX))
+                {
+                    statusCode = static_cast<uint16_t>(statusCodeInt);
+                }
+                else
+                {
+                    // TODO: bad request.
+                    break;
+                }
+            }
+            catch (...)
+            {
+                // TODO: bad request.
+                break;
+            }
+
+            // Sometimes there's a space before the payload... sometimes there's not. 🤷‍♂️
+            std::string payload;
+            if ((receivedBytes.at(3) == ' ') && (receivedBytes.size() > 4))
+            {
+                payload = std::string((receivedBytes.begin() + 4), (receivedBytes.end() - 1));
+            }
+            else
+            {
+                payload = std::string((receivedBytes.begin() + 3), (receivedBytes.end() - 1));
+            }
+
+            FtlClient::FtlResponse response
+            {
+                .statusCode = statusCode,
+                .payload = payload,
+            };
+            {
+                std::lock_guard<std::mutex> lock(recvResponseMutex);
+                receivedResponses.push(response);
+            }
+            recvResponseConditionVariable.notify_one();
+        }
+    }
+}
+
+void FtlClient::sendControlMessage(std::string message)
+{
+    write(controlSocketHandle, message.c_str(), message.size());
+}
+
+Result<FtlClient::FtlResponse> FtlClient::waitForResponse(std::chrono::milliseconds timeout)
+{
+    std::unique_lock<std::mutex> lock(recvResponseMutex);
+    recvResponseConditionVariable.wait_for(
+        lock,
+        timeout,
+        [this]() { return !receivedResponses.empty(); });
+    if (receivedResponses.empty())
+    {
+        // We've timed out
+        return Result<FtlClient::FtlResponse>::Error("Timeout expired waiting for a response.");
+    }
+    else
+    {
+        FtlClient::FtlResponse response = receivedResponses.front();
+        receivedResponses.pop();
+        return Result<FtlClient::FtlResponse>::Success(response);
+    }
 }
 #pragma endregion

--- a/src/FtlClient.cpp
+++ b/src/FtlClient.cpp
@@ -1,0 +1,83 @@
+/**
+ * @file FtlClient.cpp
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2020-12-14
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ */
+
+#include "FtlClient.h"
+
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#pragma region Constructor/Destructor
+FtlClient::FtlClient(
+    std::string targetHostname,
+    ftl_channel_id_t channelId,
+    std::vector<std::byte> streamKey) : 
+    targetHostname(targetHostname),
+    channelId(channelId),
+    streamKey(std::move(streamKey))
+{ }
+#pragma endregion Constructor/Destructor
+
+#pragma region Public methods
+Result<void> FtlClient::ConnectAsync()
+{
+    // Look up hostname
+    addrinfo addrHints { 0 };
+    addrHints.ai_family = AF_INET; // TODO: IPV6 support
+    addrHints.ai_socktype = SOCK_STREAM;
+    addrHints.ai_protocol = IPPROTO_TCP;
+    addrinfo* addrLookup = nullptr;
+    int lookupErr = getaddrinfo(
+        targetHostname.c_str(),
+        std::to_string(FTL_CONTROL_PORT).c_str(),
+        &addrHints,
+        &addrLookup);
+    if (lookupErr != 0)
+    {
+        freeaddrinfo(addrLookup);
+        return Result<void>::Error("Error looking up hostname");
+    }
+
+    // Attempt to open TCP connection
+    // TODO: Loop through additional addresses on failure. For now, only try the first one.
+    addrinfo targetAddr = *addrLookup;
+    int socketHandle = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    int connectErr = connect(socketHandle, targetAddr.ai_addr, targetAddr.ai_addrlen);
+    if (connectErr != 0)
+    {
+        freeaddrinfo(addrLookup);
+        return Result<void>::Error("Could not connect to Orchestration service on given host");
+    }
+
+    freeaddrinfo(addrLookup);
+
+    // We provide the thread with a promise that it will fulfill once the connection
+    // is ready. We block until this promise is fulfilled.
+    std::promise<void> connectionReadyPromise;
+    std::future<void> connectionReadyFuture = connectionReadyPromise.get_future();
+    connectionThread = std::thread(
+        &FtlClient::connectionThreadBody,
+        this,
+        std::move(connectionReadyPromise));
+    connectionThread.detach();
+    connectionReadyFuture.get();
+
+    return Result<void>::Success();
+}
+
+void FtlClient::SetOnClosed(std::function<void()> onClosed)
+{
+    this->onClosed = onClosed;
+}
+#pragma endregion Public methods
+
+#pragma region Private methods
+void FtlClient::connectionThreadBody(std::promise<void>&& connectionReadyPromise)
+{
+    connectionReadyPromise.set_value();
+}
+#pragma endregion

--- a/src/FtlClient.h
+++ b/src/FtlClient.h
@@ -1,0 +1,57 @@
+/**
+ * @file FtlClient.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2020-12-14
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ */
+
+#pragma once
+
+#include "FtlTypes.h"
+#include "Result.h"
+
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <string>
+#include <thread>
+#include <vector>
+
+/**
+ * @brief A faster-than-light client used to connect to other janus-ftl-plugin instances.
+ */
+class FtlClient
+{
+public:
+    /* Static public members */
+    static constexpr uint16_t FTL_CONTROL_PORT = 8084;
+
+    /* Constructor/Destructor */
+    FtlClient(
+        std::string targetHostname,
+        ftl_channel_id_t channelId,
+        std::vector<std::byte> streamKey);
+    
+    /* Public methods */
+    /**
+     * @brief Starts FTL connection on a new thread.
+     */
+    Result<void> ConnectAsync();
+
+    /**
+     * @brief Set the callback to be triggered when the connection has been closed.
+     */
+    void SetOnClosed(std::function<void()> onClosed);
+
+private:
+    /* Private members */
+    std::string targetHostname;
+    ftl_channel_id_t channelId;
+    std::vector<std::byte> streamKey;
+    std::thread connectionThread;
+    // Callbacks
+    std::function<void()> onClosed;
+
+    /* Private methods */
+    void connectionThreadBody(std::promise<void>&& connectionReadyPromise);
+};

--- a/src/FtlClient.h
+++ b/src/FtlClient.h
@@ -87,18 +87,23 @@ private:
     std::string targetHostname;
     ftl_channel_id_t channelId;
     std::vector<std::byte> streamKey;
-    int controlSocketHandle;
+    int controlSocketHandle = 0;
     std::thread connectionThread;
     std::mutex recvResponseMutex;
     std::condition_variable recvResponseConditionVariable;
     std::queue<FtlResponse> receivedResponses;
     uint16_t assignedMediaPort = 0;
+    int mediaSocketHandle = 0;
     // Callbacks
     std::function<void()> onClosed;
 
     /* Private methods */
+    Result<void> openControlConnection();
+    Result<void> authenticateControlConnection();
+    Result<void> sendControlStartStream(FtlClient::ConnectMetadata metadata);
+    Result<void> openMediaConnection();
     void connectionThreadBody();
     void sendControlMessage(std::string message);
     Result<FtlClient::FtlResponse> waitForResponse(
-        std::chrono::milliseconds timeout = std::chrono::milliseconds(5000));
+        std::chrono::milliseconds timeout = std::chrono::milliseconds(500000));
 };

--- a/src/FtlClient.h
+++ b/src/FtlClient.h
@@ -10,9 +10,13 @@
 #include "FtlTypes.h"
 #include "Result.h"
 
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <future>
+#include <mutex>
+#include <queue>
 #include <string>
 #include <thread>
 #include <vector>
@@ -26,6 +30,25 @@ public:
     /* Static public members */
     static constexpr uint16_t FTL_CONTROL_PORT = 8084;
 
+    /* Public structs */
+    struct ConnectMetadata
+    {
+        std::string VendorName;
+        std::string VendorVersion;
+
+        bool HasVideo;
+        std::string VideoCodec;
+        uint32_t VideoHeight;
+        uint32_t VideoWidth;
+        uint32_t VideoPayloadType;
+        uint32_t VideoIngestSsrc;
+
+        bool HasAudio;
+        std::string AudioCodec;
+        uint32_t AudioPayloadType;
+        uint32_t AudioIngestSsrc;
+    };
+
     /* Constructor/Destructor */
     FtlClient(
         std::string targetHostname,
@@ -36,7 +59,12 @@ public:
     /**
      * @brief Starts FTL connection on a new thread.
      */
-    Result<void> ConnectAsync();
+    Result<void> ConnectAsync(FtlClient::ConnectMetadata metadata);
+
+    /**
+     * @brief Stop the connection (blocks until close is complete)
+     */
+    void Stop();
 
     /**
      * @brief Set the callback to be triggered when the connection has been closed.
@@ -44,14 +72,33 @@ public:
     void SetOnClosed(std::function<void()> onClosed);
 
 private:
+    /* Private structs */
+    struct FtlResponse
+    {
+        uint16_t statusCode;
+        std::string payload;
+    };
+
+    /* Private static/constexpr members */
+    static constexpr int FTL_PROTOCOL_VERSION_MAJOR = 0;
+    static constexpr int FTL_PROTOCOL_VERSION_MINOR = 9;
+
     /* Private members */
     std::string targetHostname;
     ftl_channel_id_t channelId;
     std::vector<std::byte> streamKey;
+    int controlSocketHandle;
     std::thread connectionThread;
+    std::mutex recvResponseMutex;
+    std::condition_variable recvResponseConditionVariable;
+    std::queue<FtlResponse> receivedResponses;
+    uint16_t assignedMediaPort = 0;
     // Callbacks
     std::function<void()> onClosed;
 
     /* Private methods */
-    void connectionThreadBody(std::promise<void>&& connectionReadyPromise);
+    void connectionThreadBody();
+    void sendControlMessage(std::string message);
+    Result<FtlClient::FtlResponse> waitForResponse(
+        std::chrono::milliseconds timeout = std::chrono::milliseconds(5000));
 };

--- a/src/FtlStream.cpp
+++ b/src/FtlStream.cpp
@@ -176,6 +176,16 @@ VideoCodecKind FtlStream::GetVideoCodec()
     return ingestConnection->GetVideoCodec();
 }
 
+uint16_t FtlStream::GetVideoWidth()
+{
+    return ingestConnection->GetVideoWidth();
+}
+
+uint16_t FtlStream::GetVideoHeight()
+{
+    return ingestConnection->GetVideoHeight();
+}
+
 AudioCodecKind FtlStream::GetAudioCodec()
 {
     return ingestConnection->GetAudioCodec();

--- a/src/FtlStream.h
+++ b/src/FtlStream.h
@@ -45,7 +45,9 @@ public:
         const std::shared_ptr<RelayThreadPool> relayThreadPool,
         const std::shared_ptr<ServiceConnection> serviceConnection,
         const uint16_t metadataReportIntervalMs,
-        const std::string myHostname);
+        const std::string myHostname,
+        const bool nackLostPackets = true,
+        const bool generatePreviews = true);
 
     /* Public methods */
     void Start();
@@ -85,6 +87,8 @@ private:
     const std::shared_ptr<ServiceConnection> serviceConnection;
     const uint16_t metadataReportIntervalMs;
     const std::string myHostname;
+    const bool nackLostPackets;
+    const bool generatePreviews;
     ftl_stream_id_t streamId;
     janus_rtp_switching_context rtpSwitchingContext;
     int mediaSocketHandle;

--- a/src/FtlStream.h
+++ b/src/FtlStream.h
@@ -62,6 +62,8 @@ public:
     bool GetHasVideo();
     bool GetHasAudio();
     VideoCodecKind GetVideoCodec();
+    uint16_t GetVideoWidth();
+    uint16_t GetVideoHeight();
     AudioCodecKind GetAudioCodec();
     rtp_ssrc_t GetAudioSsrc();
     rtp_ssrc_t GetVideoSsrc();

--- a/src/FtlStream.h
+++ b/src/FtlStream.h
@@ -22,14 +22,15 @@ extern "C"
     #include <rtp.h>
 }
 #include <atomic>
-#include <stdint.h>
-#include <string>
-#include <memory>
-#include <thread>
 #include <functional>
+#include <future>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <set>
+#include <stdint.h>
+#include <string>
+#include <thread>
 
 class JanusSession;
 
@@ -56,6 +57,7 @@ public:
     
     /* Getters/Setters */
     ftl_channel_id_t GetChannelId();
+    ftl_stream_id_t GetStreamId();
     uint16_t GetMediaPort();
     bool GetHasVideo();
     bool GetHasAudio();
@@ -109,7 +111,7 @@ private:
 
     /* Private methods */
     void ingestConnectionClosed(IngestConnection& connection);
-    void startStreamThread();
+    void startStreamThread(std::promise<void>&& streamReadyPromise);
     void startStreamMetadataReportingThread();
     void processKeyframePacket(std::shared_ptr<std::vector<unsigned char>> rtpPacket);
     void markReceivedSequence(rtp_payload_type_t payloadType, rtp_sequence_num_t receivedSequence);

--- a/src/FtlStreamStore.cpp
+++ b/src/FtlStreamStore.cpp
@@ -247,4 +247,36 @@ void FtlStreamStore::RemovePendingViewershipForSession(std::shared_ptr<JanusSess
         JANUS_LOG(LOG_WARN, "FTL: Failed to erase session from pending channel ID session set.");
     }
 }
+
+void FtlStreamStore::AddRelay(FtlStreamStore::RelayStore relay)
+{
+    std::lock_guard<std::mutex> lock(relaysMutex);
+
+    // Check for collisions
+    if (relaysByChannelId.count(relay.ChannelId) > 0)
+    {
+        throw std::invalid_argument(
+            "Attempt to add FTL Relay with a channel ID that is already assigned.");
+    }
+
+    // Add to map
+    relaysByChannelId[relay.ChannelId] = relay;
+}
+
+std::optional<FtlStreamStore::RelayStore> FtlStreamStore::GetRelayForChannelId(
+    ftl_channel_id_t channelId)
+{
+    std::lock_guard<std::mutex> lock(relaysMutex);
+    if (relaysByChannelId.count(channelId) <= 0)
+    {
+        return std::nullopt;
+    }
+    return relaysByChannelId.at(channelId);
+}
+
+void FtlStreamStore::ClearRelay(ftl_channel_id_t channelId)
+{
+    std::lock_guard<std::mutex> lock(relaysMutex);
+    relaysByChannelId.erase(channelId);
+}
 #pragma endregion

--- a/src/FtlStreamStore.cpp
+++ b/src/FtlStreamStore.cpp
@@ -200,6 +200,20 @@ std::set<std::shared_ptr<JanusSession>> FtlStreamStore::GetPendingViewersForChan
     return std::set<std::shared_ptr<JanusSession>>(); // Empty set
 }
 
+std::optional<ftl_channel_id_t> FtlStreamStore::GetPendingChannelIdForSession(
+    std::shared_ptr<JanusSession> session)
+{
+    std::lock_guard<std::mutex> lock(pendingSessionMutex);
+
+    // Look up the channel ID
+    if (pendingSessionChannelId.count(session) <= 0)
+    {
+        return std::nullopt;
+    }
+    uint16_t channelId = pendingSessionChannelId[session];
+    return channelId;
+}
+
 std::set<std::shared_ptr<JanusSession>> FtlStreamStore::ClearPendingViewersForChannelId(
     uint16_t channelId)
 {

--- a/src/FtlStreamStore.h
+++ b/src/FtlStreamStore.h
@@ -12,6 +12,7 @@
 
 #include "FtlTypes.h"
 
+#include <list>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -145,14 +146,19 @@ public:
     void AddRelay(RelayStore relay);
 
     /**
+     * @brief Removes a relay with the given channel ID and target hostname, returning a copy
+     */
+    std::optional<RelayStore> RemoveRelay(ftl_channel_id_t channelId, std::string targetHostname);
+
+    /**
      * @brief Retrieves a relay for a given channel ID if one exists.
      */
-    std::optional<RelayStore> GetRelayForChannelId(ftl_channel_id_t channelId);
+    std::list<RelayStore> GetRelaysForChannelId(ftl_channel_id_t channelId);
 
     /**
      * @brief Removes references to any relays associated with the given channel ID
      */
-    void ClearRelay(ftl_channel_id_t channelId);
+    void ClearRelays(ftl_channel_id_t channelId);
 private:
     /* Private members */
     std::mutex channelIdMapMutex;
@@ -165,5 +171,5 @@ private:
     std::map<uint16_t, std::set<std::shared_ptr<JanusSession>>> pendingChannelIdSessions;
     std::map<std::shared_ptr<JanusSession>, uint16_t> pendingSessionChannelId;
     std::mutex relaysMutex;
-    std::map<ftl_channel_id_t, RelayStore> relaysByChannelId;
+    std::map<ftl_channel_id_t, std::list<RelayStore>> relaysByChannelId;
 };

--- a/src/FtlStreamStore.h
+++ b/src/FtlStreamStore.h
@@ -121,6 +121,12 @@ public:
     std::set<std::shared_ptr<JanusSession>> GetPendingViewersForChannelId(uint16_t channelId);
 
     /**
+     * @brief Return the channel ID if a given session is pending viewership.
+     */
+    std::optional<ftl_channel_id_t> GetPendingChannelIdForSession(
+        std::shared_ptr<JanusSession> session);
+
+    /**
      * @brief Clears pending viewer store for a given channel ID
      * @param channelId Channel ID to clear pending viewers for
      * @return std::list<std::shared_ptr<JanusSession>> List of pending viewers that were cleared

--- a/src/IngestConnection.cpp
+++ b/src/IngestConnection.cpp
@@ -84,6 +84,16 @@ VideoCodecKind IngestConnection::GetVideoCodec()
     return videoCodec;
 }
 
+uint16_t IngestConnection::GetVideoWidth()
+{
+    return videoWidth;
+}
+
+uint16_t IngestConnection::GetVideoHeight()
+{
+    return videoHeight;
+}
+
 AudioCodecKind IngestConnection::GetAudioCodec()
 {
     return audioCodec;

--- a/src/IngestConnection.cpp
+++ b/src/IngestConnection.cpp
@@ -9,6 +9,9 @@
  */
 
 #include "IngestConnection.h"
+
+#include "Util.h"
+
 #include <unistd.h>
 extern "C"
 {
@@ -238,7 +241,9 @@ void IngestConnection::processHmacCommand()
     {
         hmacPayload[i] = uniformDistribution(randomEngine);
     }
-    std::string hmacString = byteArrayToHexString(&hmacPayload[0], hmacPayload.size());
+    std::string hmacString = Util::ByteArrayToHexString(
+        reinterpret_cast<std::byte*>(&hmacPayload[0]),
+        hmacPayload.size());
     JANUS_LOG(LOG_INFO, "FTL: Sending HMAC payload: %s\n", hmacString.c_str());
     writeToSocket("200 ", 4);
     writeToSocket(hmacString.c_str(), hmacString.size());
@@ -256,16 +261,29 @@ void IngestConnection::processConnectCommand(std::string command)
         std::string hmacHashStr = matches[2].str();
 
         uint32_t channelId = static_cast<uint32_t>(std::stoul(channelIdStr));
-        std::vector<uint8_t> hmacHash = hexStringToByteArray(hmacHashStr);
+        std::vector<std::byte> hmacHash = Util::HexStringToByteArray(hmacHashStr);
 
         std::string key = serviceConnection->GetHmacKey(channelId);
 
-        uint8_t buffer[512];
+        std::byte buffer[512];
         uint32_t bufferLength;
-        HMAC(EVP_sha512(), key.c_str(), key.length(), &hmacPayload[0], hmacPayload.size(), buffer, &bufferLength);
+        HMAC(
+            EVP_sha512(),
+            key.c_str(),
+            key.length(),
+            &hmacPayload[0],
+            hmacPayload.size(),
+            reinterpret_cast<unsigned char*>(buffer),
+            &bufferLength);
 
-        JANUS_LOG(LOG_INFO, "FTL: Client hash: %s\n", hmacHashStr.c_str());
-        JANUS_LOG(LOG_INFO, "FTL: Server hash: %s\n", byteArrayToHexString(&buffer[0], bufferLength).c_str());
+        JANUS_LOG(
+            LOG_INFO,
+            "FTL: Client hash: %s\n",
+            hmacHashStr.c_str());
+        JANUS_LOG(
+            LOG_INFO,
+            "FTL: Server hash: %s\n",
+            Util::ByteArrayToHexString(&buffer[0], bufferLength).c_str());
 
         // Do the hashed values match?
         bool match = true;
@@ -431,35 +449,5 @@ void IngestConnection::processDotCommand()
 void IngestConnection::processPingCommand()
 {
     writeToSocket("201\n", 4);
-}
-
-std::string IngestConnection::byteArrayToHexString(uint8_t* byteArray, uint32_t length)
-{
-    std::stringstream returnValue;
-    returnValue << std::hex << std::setfill('0');
-    for (unsigned int i = 0; i < length; ++i)
-    {
-        returnValue << std::setw(2) << static_cast<unsigned>(byteArray[i]);
-    }
-    return returnValue.str();
-}
-
-std::vector<uint8_t> IngestConnection::hexStringToByteArray(std::string hexString)
-{
-    std::vector<uint8_t> retVal;
-    std::stringstream convertStream;
-
-    unsigned int buffer;
-    unsigned int offset = 0;
-    while (offset < hexString.length()) 
-    {
-        convertStream.clear();
-        convertStream << std::hex << hexString.substr(offset, 2);
-        convertStream >> std::hex >> buffer;
-        retVal.push_back(static_cast<uint8_t>(buffer));
-        offset += 2;
-    }
-
-    return retVal;
 }
 #pragma endregion

--- a/src/IngestConnection.h
+++ b/src/IngestConnection.h
@@ -51,6 +51,8 @@ public:
     bool GetHasVideo();
     bool GetHasAudio();
     VideoCodecKind GetVideoCodec();
+    uint16_t GetVideoWidth();
+    uint16_t GetVideoHeight();
     AudioCodecKind GetAudioCodec();
     rtp_ssrc_t GetAudioSsrc();
     rtp_ssrc_t GetVideoSsrc();

--- a/src/IngestConnection.h
+++ b/src/IngestConnection.h
@@ -103,7 +103,4 @@ private:
     void processAttributeCommand(std::string command);
     void processDotCommand();
     void processPingCommand();
-    // Utility methods
-    std::string byteArrayToHexString(uint8_t* byteArray, uint32_t length);
-    std::vector<uint8_t> hexStringToByteArray(std::string hexString);
 };

--- a/src/JanusFtl.h
+++ b/src/JanusFtl.h
@@ -97,4 +97,9 @@ private:
     janus_plugin_result* handleStartMessage(std::shared_ptr<JanusSession> session, JsonPtr message, char* transaction);
     int sendJsep(std::shared_ptr<JanusSession> session, std::shared_ptr<FtlStream> ftlStream, char* transaction);
     std::string generateSdpOffer(std::shared_ptr<JanusSession> session, std::shared_ptr<FtlStream> ftlStream);
+    // Orchestrator message handling
+    void onOrchestratorConnectionClosed();
+    ConnectionResult onOrchestratorIntro(ConnectionIntroPayload payload);
+    ConnectionResult onOrchestratorOutro(ConnectionOutroPayload payload);
+    ConnectionResult onOrchestratorStreamRelay(ConnectionRelayPayload payload);
 };

--- a/src/JanusFtl.h
+++ b/src/JanusFtl.h
@@ -16,6 +16,8 @@ extern "C"
     #include <rtcp.h>
 }
 
+#include <FtlOrchestrationClient.h>
+
 #include "Configuration.h"
 #include "RtpRelayPacket.h"
 #include "IngestServer.h"
@@ -75,6 +77,7 @@ private:
     std::shared_ptr<RelayThreadPool> relayThreadPool;
     std::unique_ptr<IngestServer> ingestServer;
     std::unique_ptr<Configuration> configuration;
+    std::shared_ptr<FtlConnection> orchestrationClient;
     uint16_t minMediaPort = 9000; // TODO: Migrate to Configuration
     uint16_t maxMediaPort = 65535; // TODO: Migrate to Configuration
     std::mutex sessionsMutex;
@@ -82,6 +85,7 @@ private:
     std::mutex portAssignmentMutex;
 
     /* Private methods */
+    void initOrchestratorConnection();
     void initServiceConnection();
     uint16_t newIngestFtlStream(std::shared_ptr<IngestConnection> connection);
     void ftlStreamClosed(FtlStream& ftlStream);

--- a/src/Result.h
+++ b/src/Result.h
@@ -1,0 +1,85 @@
+/**
+ * @file Result.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2020-12-14
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ */
+
+#pragma once
+
+#include <string>
+
+template <typename T>
+struct CommonResult
+{
+    /**
+     * @brief Did this operation result in an error?
+     */
+    bool IsError = false;
+
+    /**
+     * @brief A message explaining the error that occurred.
+     */
+    std::string ErrorMessage = "";
+};
+
+template <typename T>
+struct Result : public CommonResult<T>
+{
+    /**
+     * @brief Generate a Result object indicating success and returning a value.
+     */
+    static Result<T> Success(T value)
+    {
+        return Result<T>
+        {
+            .Value = value,
+            .IsError = false,
+            .ErrorMessage = "",
+        };
+    }
+
+    /**
+     * @brief Generate a Result object indicating failure with an optional message.
+     */
+    static Result<T> Error(const std::string& message = "")
+    {
+        return Result<T>
+        {
+            .Value = {},
+            .IsError = true,
+            .ErrorMessage = message,
+        };
+    }
+
+    /**
+     * @brief Value returned by this operation on success
+     */
+    T Value;
+};
+
+template <>
+struct Result<void> : public CommonResult<void>
+{
+    /**
+     * @brief Generate a Result object indicating success.
+     */
+    static Result<void> Success()
+    {
+        auto r = Result<void>();
+        r.IsError = false;
+        r.ErrorMessage = "";
+        return r;
+    }
+
+    /**
+     * @brief Generate a Result object indicating failure with an optional message.
+     */
+    static Result<void> Error(const std::string& message = "")
+    {
+        auto r = Result<void>();
+        r.IsError = true;
+        r.ErrorMessage = message;
+        return r;
+    }
+};

--- a/src/Result.h
+++ b/src/Result.h
@@ -31,12 +31,11 @@ struct Result : public CommonResult<T>
      */
     static Result<T> Success(T value)
     {
-        return Result<T>
-        {
-            .Value = value,
-            .IsError = false,
-            .ErrorMessage = "",
-        };
+        auto r = Result<T>();
+        r.Value = value;
+        r.IsError = false;
+        r.ErrorMessage = "";
+        return r;
     }
 
     /**
@@ -44,12 +43,11 @@ struct Result : public CommonResult<T>
      */
     static Result<T> Error(const std::string& message = "")
     {
-        return Result<T>
-        {
-            .Value = {},
-            .IsError = true,
-            .ErrorMessage = message,
-        };
+        auto r = Result<T>();
+        r.Value = {};
+        r.IsError = true;
+        r.ErrorMessage = message;
+        return r;
     }
 
     /**

--- a/src/Util.h
+++ b/src/Util.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <iomanip>
+#include <random>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -33,6 +34,9 @@ public:
         return retVal;
     }
 
+    /**
+     * @brief Converts a set of bytes to a string of hex values expressed in ASCII (ex 0001..FF)
+     */
     static std::string ByteArrayToHexString(std::byte* byteArray, uint32_t length)
     {
         std::stringstream returnValue;
@@ -43,4 +47,22 @@ public:
         }
         return returnValue.str();
     }
+
+    /**
+     * @brief Generates a random binary blob with the given size.
+     */
+    static std::vector<std::byte> GenerateRandomBinaryPayload(size_t size)
+    {
+        std::vector<std::byte> payload;
+        payload.reserve(size);
+        std::uniform_int_distribution<uint8_t> uniformDistribution(0x00, 0xFF);
+        for (unsigned int i = 0; i < size; ++i)
+        {
+            payload[i] = std::byte{ uniformDistribution(randomEngine) };
+        }
+        return payload;
+    }
+
+private:
+    inline static std::default_random_engine randomEngine { std::random_device()() };
 };

--- a/src/Util.h
+++ b/src/Util.h
@@ -1,0 +1,46 @@
+/**
+ * @file Util.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2020-12-17
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ */
+#pragma once
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+class Util
+{
+public:
+    static std::vector<std::byte> HexStringToByteArray(std::string hexString)
+    {
+        std::vector<std::byte> retVal;
+        std::stringstream convertStream;
+
+        unsigned int buffer;
+        unsigned int offset = 0;
+        while (offset < hexString.length()) 
+        {
+            convertStream.clear();
+            convertStream << std::hex << hexString.substr(offset, 2);
+            convertStream >> std::hex >> buffer;
+            retVal.push_back(static_cast<std::byte>(buffer));
+            offset += 2;
+        }
+
+        return retVal;
+    }
+
+    static std::string ByteArrayToHexString(std::byte* byteArray, uint32_t length)
+    {
+        std::stringstream returnValue;
+        returnValue << std::hex << std::setfill('0');
+        for (unsigned int i = 0; i < length; ++i)
+        {
+            returnValue << std::setw(2) << static_cast<unsigned>(byteArray[i]);
+        }
+        return returnValue.str();
+    }
+};

--- a/src/ftlclienttest.cpp
+++ b/src/ftlclienttest.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file ftlclienttest.cpp
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2020-12-18
+ * @copyright Copyright (c) 2020 Hayden McAfee
+ */
+
+#include "FtlClient.h"
+#include "Result.h"
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+int main()
+{
+    std::string streamKeyStr("aBcDeFgHiJkLmNoPqRsTuVwXyZ123456");
+    std::vector<std::byte> streamKey;
+    streamKey.reserve(streamKeyStr.size());
+    for (const char& c : streamKeyStr)
+    {
+        streamKey.push_back(static_cast<std::byte>(c));
+    }
+
+    std::unique_ptr<FtlClient> ftlClient = 
+        std::make_unique<FtlClient>("localhost", 123456789, streamKey);
+    
+    Result<void> connectResult = ftlClient->ConnectAsync(FtlClient::ConnectMetadata
+    {
+        .VendorName = "TEST CLIENT",
+        .VendorVersion = "0.0.0",
+        .HasVideo = true,
+        .VideoCodec = "H264",
+        .VideoHeight = 1080,
+        .VideoWidth = 1920,
+        .VideoPayloadType = 96,
+        .VideoIngestSsrc = 123456790,
+        .HasAudio = true,
+        .AudioCodec = "OPUS",
+        .AudioPayloadType = 97,
+        .AudioIngestSsrc = 123456789,
+    });
+
+    if (connectResult.IsError)
+    {
+        std::cout << "Error connecting: " << connectResult.ErrorMessage << std::endl;
+        return 1;
+    }
+
+    std::cout << "Connected. Enter to stop." << std::endl;
+    getchar();
+
+    return 0;
+}

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = fmt-7.1.3
+source_url = https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz
+source_filename = fmt-7.1.3.tar.gz
+source_hash = 5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/fmt/7.1.3/1/get_zip
+patch_filename = fmt-7.1.3-1-wrap.zip
+patch_hash = 6eb951a51806fd6ffd596064825c39b844c1fe1799840ef507b61a53dba08213
+
+[provide]
+fmt = fmt_dep

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = spdlog-1.8.1
+source_url = https://github.com/gabime/spdlog/archive/v1.8.1.tar.gz
+source_filename = v1.8.1.tar.gz
+source_hash = 5197b3147cfcfaa67dd564db7b878e4a4b3d9f3443801722b3915cdeced656cb
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/spdlog/1.8.1/1/get_zip
+patch_filename = spdlog-1.8.1-1-wrap.zip
+patch_hash = 76844292a8e912aec78450618271a311841b33b17000988f215ddd6c64dd71b3
+
+[provide]
+dependency_names = spdlog


### PR DESCRIPTION
This change is the first iteration of work enabling Janus-FTL to scale across multiple servers to distribute load.

This is achieved by communicating with another service, [janus-ftl-orchestrator](https://github.com/Glimesh/janus-ftl-orchestrator).

The Orchestrator service will determine which streams should be relayed where and direct various janus-ftl-plugin instances on when and where to relay their video bits accordingly. For more on this, read the documentation in the [janus-ftl-orchestrator](https://github.com/Glimesh/janus-ftl-orchestrator) repository.

At a high level, this change does the following:
- Adds `janus-ftl-orchestrator` as a git submodule so that the client header-only library `FtlOrchestrationClient` can be consumed.
- Options for configuring the Orchestrator connection added to the `Configuration` class and documented in `README.md`
- `JanusFtl` updated to open a connection to the Orchestrator via `FtlOrchestrationClient` when configured to act as an Orchestration node.
- `FtlClient` added as a means of connecting via the FTL protocol to other Janus-FTL instances and sending media data
- `JanusFtl` updated to indicate to Orchestrator when a new stream has been ingested or when it needs a stream relayed from another instance
- `JanusFtl` updated to relay streams via `FtlClient` when instructed by Orchestrator

Verified manually by testing that a single Janus FTL ingest successfully relays streams to multiple Janus FTL edge nodes.