### PR TITLE
🔑 Remove temporary stream keys when unsubscribing

### DIFF
--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -257,6 +257,17 @@ void JanusFtl::DestroySession(janus_plugin_session* handle, int* error)
         if ((configuration->GetNodeKind() == NodeKind::Edge) &&
             (viewingStream->GetViewers().size() == 0))
         {
+            // Remove temporary stream key
+            const auto& edgeServiceConnection = 
+                std::dynamic_pointer_cast<EdgeNodeServiceConnection>(
+                    serviceConnection);
+            if (edgeServiceConnection == nullptr)
+            {
+                throw std::runtime_error(
+                    "Unexpected service connection type - expected EdgeNodeServiceConnection.");
+            }
+            edgeServiceConnection->ClearStreamKey(viewingStream->GetChannelId());
+
             JANUS_LOG(LOG_INFO,
                 "FTL: Last viewer for channel %d has disconnected - unsubscribing...\n",
                 viewingStream->GetChannelId());
@@ -284,6 +295,17 @@ void JanusFtl::DestroySession(janus_plugin_session* handle, int* error)
         if ((configuration->GetNodeKind() == NodeKind::Edge) &&
             (outstandingPendingViewers.size() == 0))
         {
+            // Remove temporary stream key
+            const auto& edgeServiceConnection = 
+                std::dynamic_pointer_cast<EdgeNodeServiceConnection>(
+                    serviceConnection);
+            if (edgeServiceConnection == nullptr)
+            {
+                throw std::runtime_error(
+                    "Unexpected service connection type - expected EdgeNodeServiceConnection.");
+            }
+            edgeServiceConnection->ClearStreamKey(pendingChannelId.value());
+
             JANUS_LOG(LOG_INFO,
                 "FTL: Last pending viewer for channel %d has disconnected - unsubscribing...\n",
                 pendingChannelId.value());


### PR DESCRIPTION
When an Edge node subscribes to a stream, it generates a temporary stream key that other nodes can use to relay that stream to the Edge.

An oversight in #50 left temporary stream keys in memory even after they were no longer needed.

This change removes temporary stream keys when the Edge node unsubscribes from that channel.