### PR TITLE
Use just one relay thread to maintain order

### DIFF
--- a/src/RelayThreadPool.h
+++ b/src/RelayThreadPool.h
@@ -27,9 +27,7 @@ class RelayThreadPool
 {
 public:
     /* Constructor/Destructor */
-    RelayThreadPool(
-        std::shared_ptr<FtlStreamStore> ftlStreamStore,
-        unsigned int threadCount = std::thread::hardware_concurrency());
+    RelayThreadPool(std::shared_ptr<FtlStreamStore> ftlStreamStore);
 
     /* Public methods */
     void Start();
@@ -48,5 +46,5 @@ private:
     std::queue<RtpRelayPacket> packetRelayQueue;
 
     /* Private methods */
-    void relayThreadMethod(unsigned int threadNumber);
+    void relayThreadMethod();
 };


### PR DESCRIPTION
Addresses #57 with a workaround.

Not doing full cleanup to entirely remove the relay step because:
1. There's a big refactor in progress I don't want to cause merge conflicts for
2. Not 100% sure if removing the relay thread will improve or degrade performance, more testing would be required.

This should be pretty safe as is, most testing is anyways done on single core droplets that would only have one thread anyways.