### PR TITLE
▶💥 Fix seg fault after failed service connection StartStream

### DIFF
--- a/src/FtlControlConnection.cpp
+++ b/src/FtlControlConnection.cpp
@@ -424,7 +424,8 @@ void FtlControlConnection::processDotCommand()
         transport->GetAddr().value().sin_addr);
     if (mediaPortResult.IsError)
     {
-        spdlog::error("Could not assign media port for FTL connection.");
+        spdlog::error("Could not assign media port for FTL connection: {}",
+            mediaPortResult.ErrorMessage);
         stopConnection();
         return;
     }


### PR DESCRIPTION
Fixes #69 

The `FtlControlConnection::onStartMediaPort` callback would sometimes lead to a crash due to `FtlServer` prematurely removing the `FtlControlConnection` from the pending connection store - if an error occurs during stream negotiation inside of `FtlServer::onControlStartMediaPort` (such as the service connection refusing the StartStream request), the `FtlControlConnection` instance would be destructed before it is able to handle the error.

Fixed by waiting to remove the `FtlControlConnection` from the pending connection store until the control connection has successfully been handed off to `FtlStream`.