### PR TITLE
⏱ Time out ingest connections that don't authenticate

### DIFF
--- a/src/FtlControlConnection.cpp
+++ b/src/FtlControlConnection.cpp
@@ -239,7 +239,10 @@ void FtlControlConnection::processConnectCommand(const std::string& command)
             isAuthenticated = true;
             channelId = requestedChannelId;
             writeToTransport("200\n");
-            spdlog::info("Channel {} authenticated successfully.", requestedChannelId);
+            std::string addrStr = transport->GetAddr().has_value() ? 
+                Util::AddrToString(transport->GetAddr().value().sin_addr) : "UNKNOWN";
+            spdlog::info("{} authenticated as Channel {} successfully.", addrStr,
+                requestedChannelId);
         }
         else
         {
@@ -430,8 +433,8 @@ void FtlControlConnection::processDotCommand()
         return;
     }
     uint16_t mediaPort = mediaPortResult.Value;
-    spdlog::info("Starting stream for Channel {} on UDP port {}...", channelId, mediaPort);
     isStreaming = true;
+    spdlog::info("Assigned Channel {} media port {}", channelId, mediaPort);
     writeToTransport(fmt::format("200 hi. Use UDP port {}\n", mediaPort));
 }
 

--- a/src/FtlServer.cpp
+++ b/src/FtlServer.cpp
@@ -11,6 +11,7 @@
 #include "ConnectionListeners/ConnectionListener.h"
 #include "FtlControlConnection.h"
 #include "FtlStream.h"
+#include "Utilities/Util.h"
 
 #include <spdlog/spdlog.h>
 
@@ -55,6 +56,22 @@ void FtlServer::StartAsync()
 void FtlServer::Stop()
 {
     spdlog::info("Stopping FtlServer...");
+    // Spin down any active threads
+    isStopping = true;
+    threadShutdownConditionVariable.notify_all();
+    // Stop listening for new connections
+    ingestControlListener->StopListening();
+    // Close any open connections
+    std::unique_lock lock(streamDataMutex);
+    for (const auto& pendingPair : pendingControlConnections)
+    {
+        pendingPair.second->Stop();
+    }
+    pendingControlConnections.clear();
+    for (const auto& activePair : activeStreams)
+    {
+        activePair.second.Stream->Stop();
+    }
 }
 
 Result<void> FtlServer::StopStream(ftl_channel_id_t channelId, ftl_stream_id_t streamId)
@@ -143,6 +160,8 @@ void FtlServer::removeStreamRecord(FtlStream* stream,
 void FtlServer::onNewControlConnection(std::unique_ptr<ConnectionTransport> connection)
 {
     std::unique_lock lock(streamDataMutex);
+    std::string addrString = connection->GetAddr().has_value() ? 
+        Util::AddrToString(connection->GetAddr().value().sin_addr) : "UNKNOWN";
     auto ingestControlConnection = std::make_unique<FtlControlConnection>(
         std::move(connection),
         onRequestKey,
@@ -154,7 +173,28 @@ void FtlServer::onNewControlConnection(std::unique_ptr<ConnectionTransport> conn
         std::move(ingestControlConnection));
     ingestControlConnectionPtr->StartAsync();
 
-    spdlog::info("New FTL control connection is pending.");
+    spdlog::info("New FTL control connection is pending from {}", addrString);
+
+    // If this connection doesn't successfully auth in a certain amount of time, close it.
+    auto timeoutThread = std::thread([this, ingestControlConnectionPtr, addrString]() {
+        std::unique_lock threadLock(threadShutdownMutex);
+        threadShutdownConditionVariable.wait_for(threadLock,
+            std::chrono::milliseconds(CONNECTION_AUTH_TIMEOUT_MS));
+        if (isStopping)
+        {
+            return;
+        }
+
+        std::unique_lock streamDataLock(streamDataMutex);
+        spdlog::info("{} didn't authenticate within {}ms, closing",
+            addrString, CONNECTION_AUTH_TIMEOUT_MS);
+        if (pendingControlConnections.count(ingestControlConnectionPtr) > 0)
+        {
+            pendingControlConnections.at(ingestControlConnectionPtr)->Stop();
+            pendingControlConnections.erase(ingestControlConnectionPtr);
+        }
+    });
+    timeoutThread.detach();
 }
 
 Result<uint16_t> FtlServer::onControlStartMediaPort(FtlControlConnection& controlConnection,
@@ -216,6 +256,8 @@ Result<uint16_t> FtlServer::onControlStartMediaPort(FtlControlConnection& contro
     activeStreams.try_emplace(stream.get(), std::move(stream), mediaPort);
 
     // Pass the media port back to the control connection
+    spdlog::info("{} started streaming on Channel {} / Stream {}", 
+        Util::AddrToString(targetAddr), channelId, streamId);
     return Result<uint16_t>::Success(mediaPort);
 }
 

--- a/src/FtlServer.h
+++ b/src/FtlServer.h
@@ -114,9 +114,9 @@ private:
     const uint16_t minMediaPort;
     const uint16_t maxMediaPort;
     // Misc fields
-    std::atomic<bool> isStopping { false };
-    std::mutex threadShutdownMutex;
-    std::condition_variable threadShutdownConditionVariable;
+    bool isStopping { false };
+    std::mutex stoppingMutex;
+    std::condition_variable stoppingConditionVariable;
     std::thread listenThread;
     std::shared_mutex streamDataMutex;
     std::unordered_map<FtlControlConnection*, std::unique_ptr<FtlControlConnection>>

--- a/src/FtlServer.h
+++ b/src/FtlServer.h
@@ -12,6 +12,7 @@
 #include "Utilities/FtlTypes.h"
 #include "Utilities/Result.h"
 
+#include <condition_variable>
 #include <functional>
 #include <future>
 #include <list>
@@ -98,6 +99,7 @@ private:
     /* Constants */
     static constexpr uint16_t DEFAULT_MEDIA_MIN_PORT = 9000;
     static constexpr uint16_t DEFAULT_MEDIA_MAX_PORT = 10000;
+    static constexpr uint16_t CONNECTION_AUTH_TIMEOUT_MS = 5000;
 
     /* Private fields */
     // Connection managers
@@ -112,6 +114,9 @@ private:
     const uint16_t minMediaPort;
     const uint16_t maxMediaPort;
     // Misc fields
+    std::atomic<bool> isStopping { false };
+    std::mutex threadShutdownMutex;
+    std::condition_variable threadShutdownConditionVariable;
     std::thread listenThread;
     std::shared_mutex streamDataMutex;
     std::unordered_map<FtlControlConnection*, std::unique_ptr<FtlControlConnection>>

--- a/src/FtlStream.cpp
+++ b/src/FtlStream.cpp
@@ -75,7 +75,7 @@ Result<void> FtlStream::StartAsync()
     // Record start time
     startTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     steadyStartTime = std::chrono::steady_clock::now();
-    spdlog::info("FTL media stream started for channel {} / stream {}",
+    spdlog::info("Media stream receiving for Channel {} / Stream {}",
         controlConnection->GetChannelId(), streamId);
     return Result<void>::Success();
 }

--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -391,7 +391,7 @@ Result<ftl_stream_id_t> JanusFtl::ftlServerStreamStarted(ftl_channel_id_t channe
             });
     }
 
-    spdlog::info("New stream started. Channel {} / Stream {}.", channelId, streamId);
+    spdlog::info("Registered new stream: Channel {} / Stream {}.", channelId, streamId);
 
     return Result<ftl_stream_id_t>::Success(streamId);
 }


### PR DESCRIPTION
This change introduces a 5000ms timeout for any incoming ingest connections that don't pass HMAC authentication.

Also a bit of cleanup around `FtlServer::Stop` and some log messages.

Fixes #68 