### PR TITLE
Add configurable base path for REST service API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Configuration is achieved through environment variables.
 | `FTL_SERVICE_REST_HOSTNAME` | Hostname value (ex. `localhost`) | This is the hostname the REST service connection will attempt to reach. |
 | `FTL_SERVICE_REST_PORT` | Port number, `1`-`65535`. | This is the port used to communicate with the REST service via HTTP/HTTPS. |
 | `FTL_SERVICE_REST_HTTPS` | `0`: Use HTTP <br />`1`: Use HTTPS | Determines whether HTTPS is used to communicate with the REST service. |
+| `FTL_SERVICE_REST_PATH_BASE` | String, default: `/` | Used to add a path prefix to all REST API calls. |
 | `FTL_SERVICE_REST_AUTH_TOKEN` | String, default: `""` | Used to authenticate REST service API calls using the `Authorization` header. Leave blank to disable. |
 
 # Dockering

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -193,6 +193,12 @@ void Configuration::Load()
         restServiceUseHttps = std::stoi(varVal);
     }
 
+    // FTL_SERVICE_REST_PATH_BASE -> RestServicePathBase
+    if (char* varVal = std::getenv("FTL_SERVICE_REST_PATH_BASE"))
+    {
+        restServicePathBase = std::string(varVal);
+    }
+
     // FTL_SERVICE_REST_AUTH_TOKEN -> RestServiceAuthToken
     if (char* varVal = std::getenv("FTL_SERVICE_REST_AUTH_TOKEN"))
     {
@@ -290,6 +296,11 @@ uint16_t Configuration::GetRestServicePort()
 bool Configuration::GetRestServiceUseHttps()
 {
     return restServiceUseHttps;
+}
+
+std::string Configuration::GetRestServicePathBase()
+{
+    return restServicePathBase;
 }
 
 std::string Configuration::GetRestServiceAuthToken()

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -60,6 +60,7 @@ public:
     std::string GetRestServiceHostname();
     uint16_t GetRestServicePort();
     bool GetRestServiceUseHttps();
+    std::string GetRestServicePathBase();
     std::string GetRestServiceAuthToken();
 
 private:
@@ -97,6 +98,7 @@ private:
     std::string restServiceHostname = "localhost";
     uint16_t restServicePort = 4000;
     bool restServiceUseHttps = false;
+    std::string restServicePathBase = "/";
     std::string restServiceAuthToken;
 
     /* Private methods */

--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -503,6 +503,7 @@ void JanusFtl::initServiceConnection()
                 configuration->GetRestServiceHostname(),
                 configuration->GetRestServicePort(),
                 configuration->GetRestServiceUseHttps(),
+                configuration->GetRestServicePathBase(),
                 configuration->GetRestServiceAuthToken());
             break;
         case ServiceConnectionKind::DummyServiceConnection:

--- a/src/ServiceConnections/RestServiceConnection.cpp
+++ b/src/ServiceConnections/RestServiceConnection.cpp
@@ -21,11 +21,13 @@ RestServiceConnection::RestServiceConnection(
     std::string hostname,
     uint16_t port,
     bool useHttps,
+    std::string pathBase,
     std::string authToken)
 :
     hostname(hostname),
     port(port),
     useHttps(useHttps),
+    pathBase(pathBase),
     authToken(authToken)
 { }
 #pragma endregion

--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -29,6 +29,7 @@ public:
         std::string hostname,
         uint16_t port,
         bool useHttps,
+        std::string pathBase,
         std::string authToken);
 
     // ServiceConnection
@@ -47,6 +48,7 @@ private:
     std::string hostname;
     uint16_t port;
     bool useHttps;
+    std::string pathBase;
     std::string authToken;
 
     /* Private methods */

--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -52,8 +52,11 @@ private:
     std::string authToken;
 
     /* Private methods */
-    httplib::Client getHttpClient();
+    std::string resolvePathBase();
+    std::string createBaseUri(bool includeBase);
+    std::string constructPath(std::string path);
 
+    httplib::Client getHttpClient();
     httplib::Result runGetRequest(std::string url);
     httplib::Result runPostRequest(std::string url, JsonPtr body = nullptr, httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
     JsonPtr decodeRestResponse(httplib::Result result);


### PR DESCRIPTION
Adds a new environment variable `FTL_SERVICE_REST_PATH_BASE` (defaults to `/`) that controls the base path for all REST service API calls. Previously any REST API that wished to serve Janus FTL was required to have the routes at the base of the application. This allows the API handler to serve at a deeply nested path. The default value of `/` retains the same behavior as before.

The input from `FTL_SERVICE_REST_PATH_BASE` is sanitized so leading and trailing `/` characters are normalized. For example: `/api/`, `/api`, `api/`, and `api` all will all resolve to the same path of `http://example.com/api/...`