### PR TITLE
⌛ Fix deadlock on FtlControlConnection::stopConnection

### DIFF
--- a/src/ConnectionTransports/ConnectionTransport.h
+++ b/src/ConnectionTransports/ConnectionTransport.h
@@ -45,9 +45,10 @@ public:
     /**
      * @brief
      *  Shuts down the connection.
-     *  This function should block until the underlying transport/socket has been closed.
+     *  This function should block until the underlying transport/socket has been closed, unless
+     *  noBlock has been set.
      */
-    virtual void Stop() = 0;
+    virtual void Stop(bool noBlock = false) = 0;
 
     /**
      * @brief Write a set of bytes to the transport

--- a/src/ConnectionTransports/NetworkSocketConnectionTransport.cpp
+++ b/src/ConnectionTransports/NetworkSocketConnectionTransport.cpp
@@ -93,7 +93,7 @@ Result<void> NetworkSocketConnectionTransport::StartAsync()
     return Result<void>::Success();
 }
 
-void NetworkSocketConnectionTransport::Stop()
+void NetworkSocketConnectionTransport::Stop(bool noBlock)
 {
     if (!isStopping && !isStopped)
     {
@@ -107,7 +107,7 @@ void NetworkSocketConnectionTransport::Stop()
         }
 
         // Wait for the connection thread (only if it has actually started)
-        if (connectionThreadEndedFuture.valid())
+        if (!noBlock && connectionThreadEndedFuture.valid())
         {
             connectionThreadEndedFuture.wait();
         }
@@ -115,7 +115,10 @@ void NetworkSocketConnectionTransport::Stop()
     else if (isStopping && !isStopped)
     {
         // We're already stopping - just wait for the connnection thread to end.
-        connectionThreadEndedFuture.wait();
+        if (!noBlock && connectionThreadEndedFuture.valid())
+        {
+            connectionThreadEndedFuture.wait();
+        }
     }
 }
 

--- a/src/ConnectionTransports/NetworkSocketConnectionTransport.h
+++ b/src/ConnectionTransports/NetworkSocketConnectionTransport.h
@@ -42,7 +42,7 @@ public:
     std::optional<sockaddr_in> GetAddr() override;
     std::optional<sockaddr_in6> GetAddr6() override;
     Result<void> StartAsync() override;
-    void Stop() override;
+    void Stop(bool noBlock = false) override;
     void Write(const std::vector<std::byte>& bytes) override;
     void SetOnConnectionClosed(std::function<void(void)> onConnectionClosed) override;
     void SetOnBytesReceived(

--- a/src/FtlControlConnection.cpp
+++ b/src/FtlControlConnection.cpp
@@ -126,10 +126,13 @@ void FtlControlConnection::writeToTransport(const std::string& str)
 void FtlControlConnection::stopConnection()
 {
     // First, stop the transport
-    // (we will not receive an OnConnectionClosed if we call Stop ourselves)
-    transport->Stop();
+    // The first parameter indicates that the transport shouldn't wait for its read thread
+    // to end - this is important to prevent deadlocks, as we are likely calling from that same
+    // thread.
+    transport->Stop(true);
     
-    // Notify that we've stopped
+    // Notify that we've stopped -  we will not receive an OnConnectionClosed from the transport
+    // if we call Stop ourselves
     if (onConnectionClosed)
     {
         onConnectionClosed(*this);

--- a/src/FtlServer.cpp
+++ b/src/FtlServer.cpp
@@ -189,10 +189,10 @@ void FtlServer::onNewControlConnection(std::unique_ptr<ConnectionTransport> conn
         }
 
         std::unique_lock streamDataLock(streamDataMutex);
-        spdlog::info("{} didn't authenticate within {}ms, closing",
-            addrString, CONNECTION_AUTH_TIMEOUT_MS);
         if (pendingControlConnections.count(ingestControlConnectionPtr) > 0)
         {
+            spdlog::info("{} didn't authenticate within {}ms, closing",
+                addrString, CONNECTION_AUTH_TIMEOUT_MS);
             pendingControlConnections.at(ingestControlConnectionPtr)->Stop();
             pendingControlConnections.erase(ingestControlConnectionPtr);
         }


### PR DESCRIPTION
Fixes #74 

Before this fix, `FtlControlConnection::stopConnection(...)` would call `Stop()` on its underlying `NetworkSocketConnectionTransport`, which in turn would wait for its underlying read thread to exit. Problem is, the original call to `stopConnection(...)` was triggered by the `NetworkSocketConnectionTransport` read thread, resulting in a deadlock as the thread waits for itself to exit.

This change adds a `noBlock` parameter to `ConnectionTransport::Stop(...)`, allowing callers to indicate that it should not block on the exiting of the transport read thread. `FtlControlConnection::stopConnection(...)` uses this parameter to avoid the deadlock.

In the future it might make sense to add a separate "dispatch" thread to `NetworkSocketConnectionTransport` so callbacks aren't tied to the actual read/write thread, which would avoid deadlocks like this one at the cost of a little synchronization overhead.