### PR TITLE
🕰️ Add expiration delta to Glimesh access tokens and use steady clock

### DIFF
--- a/src/ServiceConnections/GlimeshServiceConnection.h
+++ b/src/ServiceConnections/GlimeshServiceConnection.h
@@ -48,20 +48,22 @@ public:
 private:
     /* Private members */
     const int MAX_RETRIES = 5;
-    const int TIME_BETWEEN_RETRIES_MS = 3000;
+    const std::chrono::milliseconds TIME_BETWEEN_RETRIES = std::chrono::seconds(3);
+    // Account for potential server-to-server clock skew and network delay by considering
+    // an access token as expired well before its actual expiration time.
+    const std::chrono::milliseconds ACCESS_TOKEN_EXPIRATION_DELTA = std::chrono::seconds(10);
     std::string hostname;
     uint16_t port;
     bool useHttps;
     std::string clientId;
     std::string clientSecret;
     std::string accessToken;
-    std::time_t accessTokenExpirationTime;
+    std::chrono::steady_clock::time_point accessTokenExpirationTime;
     std::mutex authMutex;
 
     /* Private methods */
     httplib::Client getHttpClient();
-    void ensureAuth();
-    JsonPtr runGraphQlQuery(std::string query, JsonPtr variables = nullptr, httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
-    JsonPtr processGraphQlResponse(httplib::Result result);
-    tm parseIso8601DateTime(std::string dateTimeString);
+    std::string getAccessToken();
+    JsonPtr runGraphQLQuery(std::string query, JsonPtr variables = nullptr, httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
+    JsonPtr processGraphQLResponse(httplib::Result result);
 };

--- a/src/ServiceConnections/RestServiceConnection.cpp
+++ b/src/ServiceConnections/RestServiceConnection.cpp
@@ -208,13 +208,9 @@ httplib::Client RestServiceConnection::getHttpClient()
     std::string baseUri = createBaseUri(false);
     httplib::Client client = httplib::Client(baseUri.c_str());
 
-    if (authToken.length() > 0)
+    if (!authToken.empty())
     {
-        httplib::Headers headers
-        {
-            {"Authorization", authToken}
-        };
-        client.set_default_headers(headers);
+        client.set_bearer_token_auth(authToken.c_str());
     }
 
     return client;


### PR DESCRIPTION
Basically [time is hard](https://gist.github.com/timvisee/fcda9bbdff88d45cc9061606b4b923ca) and there were a couple edge cases with token refreshing that I think would be so rare the retry logic would have hid them, but I felt like addressing them.

1. There is network delay between when we check if an access token is expired and when the request hits the other server and that server checks if the token is expired. This delay create a window of a few milliseconds where we should have renewed the token but use it anyways and the request will fail.
2. There can be clock skew between the authorizing server, the janus server, and the destination server the access token is sent to.
3. Time synchronization can cause jumps in the system clock, I like to follow the general rule from the [Golang docs](https://golang.org/pkg/time/#hdr-Monotonic_Clocks) "the wall clock is for telling time and the monotonic clock is for measuring time"

The normal solution I've seen to this is to just add `expires_in` to your local monotonic clock and expire the token a few seconds early to account for the network delay / any clock drift. This keeps the logic simple and does not call for a non-standard `created_at` field etc. I think the Golang team write some great and very readable code, their oauth2 lib covers all this nicely: https://github.com/golang/oauth2/blob/master/token.go#L22

Not sure how to test this though? Partly thinking this is a good excuse for me to figure that out :)

Also this does not add retries for token request failures, that's mentioned and is a good idea to address, but I got distracted on this first.

Also `git ls-files | entr ninja -C builddir` is neat.