### PR TITLE
🌊 Enable restricting max bandwidth of incoming streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Configuration is achieved through environment variables.
 | `FTL_ORCHESTRATOR_REGION_CODE` | String value, default: `global` | This is a string value used by the Orchestrator to group regional nodes together to more effectively distribute video traffic. |
 | `FTL_SERVICE_CONNECTION` | `DUMMY`: (default) Dummy service connection <br />`GLIMESH`: Glimesh service connection <br />`REST`: REST service connection ([docs](docs/REST_SERVICE.md)) | This configuration value determines which service FTL should plug into for operations such as stream key retrieval. |
 | `FTL_SERVICE_METADATAREPORTINTERVALMS` | Time in milliseconds | Defaults to `4000`, controls how often FTL stream metadata will be reported to the service. |
-| `FTL_SERVICE_DUMMY_HMAC_KEY` | String, default: `aBcDeFgHiJkLmNoPqRsTuVwXyZ123456` | Key all FTL clients must use if service connection is `DUMMY`. The HMAC key is the part after the dash in a stream key.` |
+| `FTL_MAX_ALLOWED_BITS_PER_SECOND` | Integer bits per second | Defaults to `0` (disabled), FTL connections that exceed the bandwidth specified here will be stopped.<br />**Note that this is a strictly enforced maximum** based on a rolling average; consider providing some buffer size for encoder spikes above the configured average. |
+| `FTL_SERVICE_DUMMY_HMAC_KEY` | String, default: `aBcDeFgHiJkLmNoPqRsTuVwXyZ123456` | Key all FTL clients must use if service connection is `DUMMY`. The HMAC key is the part after the dash in a stream key. |
 | `FTL_SERVICE_DUMMY_PREVIEWIMAGEPATH` | `/path/to/directory` | The path where preview images of ingested streams will be stored if service connection is `DUMMY`. Defaults to `~/.ftl/previews` |
 | `FTL_SERVICE_GLIMESH_HOSTNAME` | Hostname value (ex. `localhost`, `glimesh.tv`) | This is the hostname the Glimesh service connection will attempt to reach. |
 | `FTL_SERVICE_GLIMESH_PORT` | Port number, `1`-`65535`. | This is the port used to communicate with the Glimesh service via HTTP/HTTPS. |

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -123,6 +123,12 @@ void Configuration::Load()
         serviceConnectionMetadataReportIntervalMs = std::stoi(varVal);
     }
 
+    // FTL_MAX_ALLOWED_BITS_PER_SECOND -> MaxAllowedBitsPerSecond
+    if (char* varVal = std::getenv("FTL_MAX_ALLOWED_BITS_PER_SECOND"))
+    {
+        maxAllowedBitsPerSecond = std::stoi(varVal);
+    }
+
     // FTL_SERVICE_DUMMY_HMAC_KEY -> DummyHmacKey
     if (char* varVal = std::getenv("FTL_SERVICE_DUMMY_HMAC_KEY"))
     {
@@ -256,6 +262,11 @@ std::string Configuration::GetDummyPreviewImagePath()
 uint16_t Configuration::GetServiceConnectionMetadataReportIntervalMs()
 {
     return serviceConnectionMetadataReportIntervalMs;
+}
+
+uint32_t Configuration::GetMaxAllowedBitsPerSecond()
+{
+    return maxAllowedBitsPerSecond;
 }
 
 std::string Configuration::GetGlimeshServiceHostname()

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -44,6 +44,7 @@ public:
     std::string GetOrchestratorRegionCode();
     ServiceConnectionKind GetServiceConnectionKind();
     uint16_t GetServiceConnectionMetadataReportIntervalMs();
+    uint32_t GetMaxAllowedBitsPerSecond();
 
     // Dummy Service Connection Values
     std::vector<std::byte> GetDummyHmacKey();
@@ -73,6 +74,7 @@ private:
     std::string orchestratorRegionCode = "global";
     ServiceConnectionKind serviceConnectionKind = ServiceConnectionKind::DummyServiceConnection;
     uint16_t serviceConnectionMetadataReportIntervalMs = 4000;
+    uint32_t maxAllowedBitsPerSecond = 0;
 
     // Dummy Service Connection Backing Stores
     // "aBcDeFgHiJkLmNoPqRsTuVwXyZ123456"

--- a/src/ConnectionTransports/NetworkSocketConnectionTransport.h
+++ b/src/ConnectionTransports/NetworkSocketConnectionTransport.h
@@ -56,8 +56,9 @@ private:
     const NetworkSocketConnectionKind connectionKind;
     const int socketHandle = 0;
     std::optional<sockaddr_in> targetAddr = std::nullopt;
-    std::atomic<bool> isStopping { false }; // Indicates that the socket has been requested to close
-    std::atomic<bool> isStopped { false };  // Indicates that the socket has finished closing
+    std::mutex stoppingMutex;
+    bool isStopping = false; // Indicates that the socket has been requested to close
+    bool isStopped = false;  // Indicates that the socket has finished closing
     std::thread connectionThread;
     std::future<void> connectionThreadEndedFuture;
     std::mutex writeMutex;

--- a/src/FtlControlConnection.h
+++ b/src/FtlControlConnection.h
@@ -31,6 +31,29 @@ public:
     using StartMediaPortCallback = std::function<Result<uint16_t>(
         FtlControlConnection&, ftl_channel_id_t, MediaMetadata, in_addr)>;
     using ConnectionClosedCallback = std::function<void(FtlControlConnection&)>;
+    enum FtlResponseCode
+    {
+        // See ftl-sdk/ftl_private.h
+        FTL_INGEST_RESP_UNKNOWN = 0,
+        FTL_INGEST_RESP_OK = 200,
+        FTL_INGEST_RESP_PING = 201,
+        FTL_INGEST_RESP_BAD_REQUEST = 400,
+        FTL_INGEST_RESP_UNAUTHORIZED = 401,
+        FTL_INGEST_RESP_OLD_VERSION = 402,
+        FTL_INGEST_RESP_AUDIO_SSRC_COLLISION = 403,
+        FTL_INGEST_RESP_VIDEO_SSRC_COLLISION = 404,
+        FTL_INGEST_RESP_INVALID_STREAM_KEY = 405,
+        FTL_INGEST_RESP_CHANNEL_IN_USE = 406,
+        FTL_INGEST_RESP_REGION_UNSUPPORTED = 407,
+        FTL_INGEST_RESP_NO_MEDIA_TIMEOUT = 408,
+        FTL_INGEST_RESP_GAME_BLOCKED = 409,
+        FTL_INGEST_RESP_SERVER_TERMINATE = 410,
+        FTL_INGEST_RESP_INTERNAL_SERVER_ERROR = 500,
+        FTL_INGEST_RESP_INTERNAL_MEMORY_ERROR = 900,
+        FTL_INGEST_RESP_INTERNAL_COMMAND_ERROR = 901,
+        FTL_INGEST_RESP_INTERNAL_SOCKET_CLOSED = 902,
+        FTL_INGEST_RESP_INTERNAL_SOCKET_TIMEOUT = 903,
+    };
 
     /* Constructor/Destructor */
     FtlControlConnection(
@@ -45,7 +68,7 @@ public:
 
     /* Public functions */
     Result<void> StartAsync();
-    void Stop();
+    void Stop(FtlResponseCode responseCode = FtlResponseCode::FTL_INGEST_RESP_SERVER_TERMINATE);
 
 private:
     /* Constants */

--- a/src/JanusFtl.h
+++ b/src/JanusFtl.h
@@ -113,6 +113,7 @@ private:
     std::shared_ptr<FtlConnection> orchestrationClient;
     std::shared_ptr<ServiceConnection> serviceConnection;
     std::unordered_map<VideoCodecKind, std::unique_ptr<PreviewGenerator>> previewGenerators;
+    uint32_t maxAllowedBitsPerSecond = 0;
     uint32_t metadataReportIntervalMs = 0;
     uint16_t minMediaPort = 9000; // TODO: Migrate to Configuration
     uint16_t maxMediaPort = 10000; // TODO: Migrate to Configuration


### PR DESCRIPTION
Fixes #42

This change introduces the `FTL_MAX_ALLOWED_BITS_PER_SECOND` configuration, providing a means of restricting the maximum bandwidth any given stream is allowed to consume before it is kicked off the server.

There are a few other changes in this payload as well:
- `FtlControlConnection::FtlResponseCode` enum is introduced (from [ftl-sdk](https://github.com/microsoft/ftl-sdk/blob/d0c8469f66806b5ea738d607f7d2b000af8b1129/libftl/ftl_private.h#L365-L385)), and is now referenced instead of hard-coded string values throughout `FtlControlConnection`.
- Better locking mechanisms around `NetworkSocketConnectionTransport`'s stopping procedure to prevent getting into a deadlocked state if the server is trying to stop a stream around the same time a client is.

An issue #79 was also discovered where pending writes to a `NetworkSocketConnectionTransport` aren't flushed when the connection is stopped, preventing us from communicating the response code to the client before closing the connection.

Worth noting as well is that [OBS behavior](https://github.com/obsproject/obs-studio/blob/92a7c12909556d8b64e1ea68a80a255b46d672cf/plugins/obs-outputs/ftl-stream.c#L888-L892) when a stream connection is terminated (even with a valid error response) is to reconnect every ten seconds, regardless of the error received. The net user result is OBS transparently trying to reconnect in a loop despite the server kicking them off for excessive bandwidth use.

![OBS reconnecting in a loop](https://user-images.githubusercontent.com/5422053/107927037-50836f80-6f2b-11eb-97fd-f55f382d39e3.png)
