### PR TITLE
📚 Update cpp-httplib, plus additional logging on failed HTTP requests

### DIFF
--- a/src/ServiceConnections/GlimeshServiceConnection.h
+++ b/src/ServiceConnections/GlimeshServiceConnection.h
@@ -47,8 +47,9 @@ public:
 
 private:
     /* Private members */
-    const int MAX_RETRIES = 5;
+    const int MAX_RETRIES = 10;
     const int TIME_BETWEEN_RETRIES_MS = 3000;
+    httplib::Client httpClient;
     std::string hostname;
     uint16_t port;
     bool useHttps;
@@ -59,9 +60,8 @@ private:
     std::mutex authMutex;
 
     /* Private methods */
-    httplib::Client getHttpClient();
     void ensureAuth();
     JsonPtr runGraphQlQuery(std::string query, JsonPtr variables = nullptr, httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
-    JsonPtr processGraphQlResponse(httplib::Result result);
+    JsonPtr processGraphQlResponse(const httplib::Result& result);
     tm parseIso8601DateTime(std::string dateTimeString);
 };

--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -45,6 +45,7 @@ private:
     /* Private members */
     const int MAX_RETRIES = 5;
     const int TIME_BETWEEN_RETRIES_MS = 3000;
+    httplib::Client httpClient;
     std::string hostname;
     uint16_t port;
     bool useHttps;
@@ -56,8 +57,8 @@ private:
     std::string createBaseUri(bool includeBase);
     std::string constructPath(std::string path);
 
-    httplib::Client getHttpClient();
     httplib::Result runGetRequest(std::string url);
-    httplib::Result runPostRequest(std::string url, JsonPtr body = nullptr, httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
-    JsonPtr decodeRestResponse(httplib::Result result);
+    httplib::Result runPostRequest(std::string url, JsonPtr body = nullptr,
+        httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
+    JsonPtr decodeRestResponse(const httplib::Result& result);
 };


### PR DESCRIPTION
This change updates us to `v0.8.4` of [cpp-httplib](https://github.com/yhirose/cpp-httplib), which includes a decent number of fixes to bugs that I suspect may be causing some of our HTTPS request failures we're seeing in production.

As a result of some of the changes in the httplib update, a few changes were made to the ServiceConnection implementations to avoid copying of `httplib::Client` and `httplib::Result` instances (they are now backed by `unique_ptr`).

Additional logging detail was also added in the Glimesh HTTP request failure case so we can determine root cause if this doesn't resolve the failures.

Verified by testing against local glimesh.tv instance.