### PR TITLE
💤 Fix crash in REST service connection

### DIFF
--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -53,12 +53,10 @@ private:
     std::string authToken;
 
     /* Private methods */
-    std::string resolvePathBase();
-    std::string createBaseUri(bool includeBase);
-    std::string constructPath(std::string path);
-
-    httplib::Result runGetRequest(std::string url);
-    httplib::Result runPostRequest(std::string url, JsonPtr body = nullptr,
+    std::string getHostUrl(bool https, std::string hostname, uint16_t port);
+    std::string relativeToAbsolutePath(std::string relativePath);
+    httplib::Result runGetRequest(std::string path);
+    httplib::Result runPostRequest(std::string path, JsonPtr body = nullptr,
         httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
     JsonPtr decodeRestResponse(const httplib::Result& result);
 };


### PR DESCRIPTION
Fixes a crash in the RestServiceConnection that was introduced by #81

The member initializer list was attempting to initialize the `httpClient` member with other member values that had not yet been initialized themselves.

Did a little bit of cleanup as well, replacing `stringstream` with `fmt::format`.