### PR TITLE
0️⃣ Allow zero length UDP socket reads

### DIFF
--- a/src/ConnectionTransports/NetworkSocketConnectionTransport.cpp
+++ b/src/ConnectionTransports/NetworkSocketConnectionTransport.cpp
@@ -249,8 +249,12 @@ void NetworkSocketConnectionTransport::connectionThreadBody(
             else if (bytesRead == 0)
             {
                 // Our peer has closed the connection.
-                closeConnection();
-                return;
+                // Unless we're a UDP connection, in which case 0 length is a-okay.
+                if (connectionKind != NetworkSocketConnectionKind::Udp)
+                {
+                    closeConnection();
+                    return;
+                }
             }
             else if (bytesRead > 0)
             {


### PR DESCRIPTION
While a zero-length read on a non-blocking TCP socket indicates the client has closed the connection, it does not mean the same for UDP, where zero-length packets are allowed.

Sometimes the FTL client will choke up a bit if the machine is under load and send a few empty UDP packets - we don't want to close their connection in this case. Discovered this while load testing.