### PR TITLE
🔪 Kill streams on metadata report error

### DIFF
--- a/src/ServiceConnections/DummyServiceConnection.cpp
+++ b/src/ServiceConnections/DummyServiceConnection.cpp
@@ -50,8 +50,8 @@ Result<ftl_stream_id_t> DummyServiceConnection::StartStream(ftl_channel_id_t cha
     return Result<ftl_stream_id_t>::Success(currentStreamId++);
 }
 
-Result<void> DummyServiceConnection::UpdateStreamMetadata(ftl_stream_id_t streamId,
-    StreamMetadata metadata)
+Result<ServiceConnection::ServiceResponse> DummyServiceConnection::UpdateStreamMetadata(
+    ftl_stream_id_t streamId, StreamMetadata metadata)
 {
     spdlog::debug("Stats received for stream {}:"
         "\n\tStreamTimeSeconds: {}"
@@ -81,7 +81,7 @@ Result<void> DummyServiceConnection::UpdateStreamMetadata(ftl_stream_id_t stream
         metadata.audioCodec,
         metadata.videoWidth,
         metadata.videoHeight);
-    return Result<void>::Success();
+    return Result<ServiceResponse>::Success(ServiceResponse::Ok);
 }
 
 Result<void> DummyServiceConnection::EndStream(ftl_stream_id_t streamId)

--- a/src/ServiceConnections/DummyServiceConnection.h
+++ b/src/ServiceConnections/DummyServiceConnection.h
@@ -29,7 +29,8 @@ public:
     void Init() override;
     Result<std::vector<std::byte>> GetHmacKey(ftl_channel_id_t channelId) override;
     Result<ftl_stream_id_t> StartStream(ftl_channel_id_t channelId) override;
-    Result<void> UpdateStreamMetadata(ftl_stream_id_t streamId, StreamMetadata metadata) override;
+    Result<ServiceResponse> UpdateStreamMetadata(ftl_stream_id_t streamId,
+        StreamMetadata metadata) override;
     Result<void> EndStream(ftl_stream_id_t streamId) override;
     Result<void> SendJpegPreviewImage(ftl_stream_id_t streamId,
         std::vector<uint8_t> jpegData) override;

--- a/src/ServiceConnections/EdgeNodeServiceConnection.cpp
+++ b/src/ServiceConnections/EdgeNodeServiceConnection.cpp
@@ -54,10 +54,10 @@ Result<ftl_stream_id_t> EdgeNodeServiceConnection::StartStream(ftl_channel_id_t 
     return Result<ftl_stream_id_t>::Success(lastAssignedStreamId++);
 }
 
-Result<void> EdgeNodeServiceConnection::UpdateStreamMetadata(ftl_stream_id_t streamId,
-    StreamMetadata metadata)
+Result<ServiceConnection::ServiceResponse> EdgeNodeServiceConnection::UpdateStreamMetadata(
+    ftl_stream_id_t streamId, StreamMetadata metadata)
 {
-    return Result<void>::Success();
+    return Result<ServiceResponse>::Success(ServiceResponse::Ok);
 }
 
 Result<void> EdgeNodeServiceConnection::EndStream(ftl_stream_id_t streamId)

--- a/src/ServiceConnections/EdgeNodeServiceConnection.h
+++ b/src/ServiceConnections/EdgeNodeServiceConnection.h
@@ -39,9 +39,11 @@ public:
     void Init() override;
     Result<std::vector<std::byte>> GetHmacKey(ftl_channel_id_t channelId) override;
     Result<ftl_stream_id_t> StartStream(ftl_channel_id_t channelId) override;
-    Result<void> UpdateStreamMetadata(ftl_stream_id_t streamId, StreamMetadata metadata) override;
+    Result<ServiceResponse> UpdateStreamMetadata(ftl_stream_id_t streamId,
+        StreamMetadata metadata) override;
     Result<void> EndStream(ftl_stream_id_t streamId) override;
-    Result<void> SendJpegPreviewImage(ftl_stream_id_t streamId, std::vector<uint8_t> jpegData) override;
+    Result<void> SendJpegPreviewImage(ftl_stream_id_t streamId,
+        std::vector<uint8_t> jpegData) override;
 
 private:
     /* Static private members */

--- a/src/ServiceConnections/GlimeshServiceConnection.h
+++ b/src/ServiceConnections/GlimeshServiceConnection.h
@@ -40,7 +40,8 @@ public:
     void Init() override;
     Result<std::vector<std::byte>> GetHmacKey(ftl_channel_id_t channelId) override;
     Result<ftl_stream_id_t> StartStream(ftl_channel_id_t channelId) override;
-    Result<void> UpdateStreamMetadata(ftl_stream_id_t streamId, StreamMetadata metadata) override;
+    Result<ServiceResponse> UpdateStreamMetadata(ftl_stream_id_t streamId,
+        StreamMetadata metadata) override;
     Result<void> EndStream(ftl_stream_id_t streamId) override;
     Result<void> SendJpegPreviewImage(ftl_stream_id_t streamId,
         std::vector<uint8_t> jpegData) override;

--- a/src/ServiceConnections/RestServiceConnection.cpp
+++ b/src/ServiceConnections/RestServiceConnection.cpp
@@ -108,8 +108,8 @@ Result<ftl_stream_id_t> RestServiceConnection::StartStream(ftl_channel_id_t chan
     return Result<ftl_stream_id_t>::Error("Could not start stream.");
 }
 
-Result<void> RestServiceConnection::UpdateStreamMetadata(ftl_stream_id_t streamId,
-    StreamMetadata metadata)
+Result<ServiceConnection::ServiceResponse> RestServiceConnection::UpdateStreamMetadata(
+    ftl_stream_id_t streamId, StreamMetadata metadata)
 {
     JsonPtr streamMetadata(json_pack(
         "{s:s, s:s, s:i, s:i, s:i, s:i, s:i, s:i, s:i, s:s, s:s, s:s, s:i, s:i}",
@@ -130,7 +130,8 @@ Result<void> RestServiceConnection::UpdateStreamMetadata(ftl_stream_id_t streamI
     ));
 
     runPostRequest(fmt::format("metadata/{}", streamId), std::move(streamMetadata));
-    return Result<void>::Success();
+    return Result<ServiceConnection::ServiceResponse>::Success(
+        ServiceConnection::ServiceResponse::Ok);
 }
 
 Result<void> RestServiceConnection::EndStream(ftl_stream_id_t streamId)

--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -36,7 +36,8 @@ public:
     void Init() override;
     Result<std::vector<std::byte>> GetHmacKey(ftl_channel_id_t channelId) override;
     Result<ftl_stream_id_t> StartStream(ftl_channel_id_t channelId) override;
-    Result<void> UpdateStreamMetadata(ftl_stream_id_t streamId, StreamMetadata metadata) override;
+    Result<ServiceResponse> UpdateStreamMetadata(ftl_stream_id_t streamId,
+        StreamMetadata metadata) override;
     Result<void> EndStream(ftl_stream_id_t streamId) override;
     Result<void> SendJpegPreviewImage(ftl_stream_id_t streamId,
         std::vector<uint8_t> jpegData) override;

--- a/src/ServiceConnections/ServiceConnection.h
+++ b/src/ServiceConnections/ServiceConnection.h
@@ -24,6 +24,15 @@
 class ServiceConnection
 {
 public:
+    /**
+     * @brief Describes a set of responses that can be returned by a ServiceConnection
+     */
+    enum class ServiceResponse
+    {
+        Ok = 0,
+        EndStream
+    };
+
     virtual ~ServiceConnection()
     { }
 
@@ -54,7 +63,7 @@ public:
      * @param streamId ID of stream to update
      * @param metadata metadata of stream
      */
-    virtual Result<void> UpdateStreamMetadata(ftl_stream_id_t streamId,
+    virtual Result<ServiceResponse> UpdateStreamMetadata(ftl_stream_id_t streamId,
         StreamMetadata metadata) = 0;
 
     /**


### PR DESCRIPTION
This change updates the `GlimeshServiceConnection` to properly respond to changes introduced here: https://github.com/Glimesh/glimesh.tv/pull/483

If a GraphQL error is returned by the service while updating metadata for a stream, that stream will be stopped.

This serves as a mechanism for the service to shut down currently running streams.