### PR TITLE
Update logging in GlimeshServiceConnection.cpp

### DIFF
--- a/src/ServiceConnections/GlimeshServiceConnection.cpp
+++ b/src/ServiceConnections/GlimeshServiceConnection.cpp
@@ -272,7 +272,7 @@ void GlimeshServiceConnection::ensureAuth()
 
                 std::time_t currentTime = std::time(nullptr);
                 spdlog::info("Received new access token, expires in {} - {} = {} seconds",
-                    accessToken, expirationTime, currentTime, (expirationTime - currentTime));
+                    expirationTime, currentTime, (expirationTime - currentTime));
 
                 // Update HTTP client Authorization header
                 httplib::Headers headers


### PR DESCRIPTION
Access token was still being logged, number of format slots was changed but not the arguments.

ex:
```
[2021-02-27 00:42:27.912] [info] Received new access token, expires in ee8f831cfa0d45a7675ca65c0df6daa9be95681ad185f0a408d40a0c45b6bf32 - 1614462965 = 1614415347 seconds
```