### PR TITLE
🎡 FtlClient spin lock fix

### DIFF
--- a/src/FtlClient.cpp
+++ b/src/FtlClient.cpp
@@ -313,7 +313,7 @@ void FtlClient::connectionThreadBody()
     {
         readBytes = read(controlSocketHandle, recvBuffer, sizeof(recvBuffer));
 
-        if (readBytes < 0)
+        if (readBytes <= 0)
         {
             // TODO: We're closing or something went wrong
             break;


### PR DESCRIPTION
This fixes an issue that would occur when an FtlClient control connection was closed where the client would spin indefinitely trying to read the socket.