### PR TITLE
⌛ Set FtlClient connection timeout value to something more sane

### DIFF
--- a/src/FtlClient.h
+++ b/src/FtlClient.h
@@ -121,5 +121,5 @@ private:
     void endConnection();
     void sendControlMessage(std::string message);
     Result<FtlClient::FtlResponse> waitForResponse(
-        std::chrono::milliseconds timeout = std::chrono::milliseconds(500000));
+        std::chrono::milliseconds timeout = std::chrono::milliseconds(1000));
 };


### PR DESCRIPTION
Fixing what I assume was a leftover debugging value - the FtlClient now waits 1 second before timing out instead of 500 seconds.