### PR TITLE
⌚🐕 Watchdog support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Install Dependency Packages
-      run: sudo apt update && sudo apt install libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build libavcodec-dev
+      run: sudo apt update && sudo apt install libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build libavcodec-dev libsystemd-dev
     - name: Install meson
       run: sudo -H pip3 install meson
     - name: Clone libnice

--- a/README.md
+++ b/README.md
@@ -128,6 +128,29 @@ Configuration is achieved through environment variables.
     docker build -t janus-ftl .
     docker run --rm -p 8084:8084/tcp -p 8088:8088/tcp -p 9000-9100:9000-9100/udp -p 20000-20100:20000-20100/udp -e "DOCKER_IP=HOST.IP.ADDRESS.HERE" janus-ftl
 
+# systemd
+
+This plugin will have systemd watchdog support if the `libsystemd-dev` package is installed. To enable this integration set `WatchdogSec` in your service unit file. The following is a sample service unit for running this plugin under systemd with reasonable defaults.
+
+```systemd
+[Unit]
+Description=Janus WebRTC Server with FTL support
+Requires=network.target
+After=syslog.target network.target
+
+[Service]
+Type=notify
+ExecStart=/opt/janus/bin/janus -o
+Restart=on-failure
+RestartSec=10
+WatchdogSec=60
+
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+```
+
 # Misc Notes
 
 ## Streaming from OBS

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ installdir = get_variable('INSTALL_PATH', (januspath + '/lib/janus/plugins'))
 sources = files([
     # Utilities
     'src/Utilities/Rtp.cpp',
+    'src/Utilities/Watchdog.cpp',
     # Preview Generators
     'src/PreviewGenerators/H264PreviewGenerator.cpp',
     # Service Connections
@@ -57,6 +58,14 @@ fmt_wrap = subproject('fmt', default_options: 'default_library=static')
 meson.override_dependency('fmt', fmt_wrap.get_variable('fmt_dep')) # Use our copy of fmt for spdlog
 spdlog_wrap = subproject('spdlog', default_options: ['default_library=static', 'compile_library=true', 'external_fmt=true'] )
 
+# Optional libsystemd dep for watchdog monitoring support
+systemd_dep = dependency('libsystemd', required : get_option('systemd_watchdog_support'))
+if systemd_dep.found()
+  add_project_arguments('-DSYSTEMD_WATCHDOG_SUPPORT', language: 'cpp') 
+else
+  systemd_dep = disabler()
+endif
+
 deps = [
     dependency('glib-2.0'),
     dependency('libsrtp2'),
@@ -68,6 +77,7 @@ deps = [
     # Meson wrapped dependencies
     fmt_wrap.get_variable('fmt_dep'),
     spdlog_wrap.get_variable('spdlog_dep'),
+    systemd_dep,
 ]
 
 incdir = include_directories(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('systemd_watchdog_support', type : 'feature', value : 'auto') # http://0pointer.de/blog/projects/watchdog.html

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -117,10 +117,10 @@ void Configuration::Load()
         }
     }
 
-    // FTL_SERVICE_METADATAREPORTINTERVALMS -> ServiceConnectionMetadataReportIntervalMs
+    // FTL_SERVICE_METADATAREPORTINTERVALMS -> ServiceConnectionMetadataReportInterval
     if (char* varVal = std::getenv("FTL_SERVICE_METADATAREPORTINTERVALMS"))
     {
-        serviceConnectionMetadataReportIntervalMs = std::stoi(varVal);
+        serviceConnectionMetadataReportInterval = std::chrono::milliseconds(std::stoi(varVal));
     }
 
     // FTL_MAX_ALLOWED_BITS_PER_SECOND -> MaxAllowedBitsPerSecond
@@ -259,9 +259,9 @@ std::string Configuration::GetDummyPreviewImagePath()
     return dummyPreviewImagePath;
 }
 
-uint16_t Configuration::GetServiceConnectionMetadataReportIntervalMs()
+std::chrono::milliseconds Configuration::GetServiceConnectionMetadataReportInterval()
 {
-    return serviceConnectionMetadataReportIntervalMs;
+    return serviceConnectionMetadataReportInterval;
 }
 
 uint32_t Configuration::GetMaxAllowedBitsPerSecond()

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -43,7 +44,7 @@ public:
     std::vector<std::byte> GetOrchestratorPsk();
     std::string GetOrchestratorRegionCode();
     ServiceConnectionKind GetServiceConnectionKind();
-    uint16_t GetServiceConnectionMetadataReportIntervalMs();
+    std::chrono::milliseconds GetServiceConnectionMetadataReportInterval();
     uint32_t GetMaxAllowedBitsPerSecond();
 
     // Dummy Service Connection Values
@@ -73,7 +74,7 @@ private:
     std::vector<std::byte> orchestratorPsk;
     std::string orchestratorRegionCode = "global";
     ServiceConnectionKind serviceConnectionKind = ServiceConnectionKind::DummyServiceConnection;
-    uint16_t serviceConnectionMetadataReportIntervalMs = 4000;
+    std::chrono::milliseconds serviceConnectionMetadataReportInterval = std::chrono::milliseconds(4000);
     uint32_t maxAllowedBitsPerSecond = 0;
 
     // Dummy Service Connection Backing Stores

--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -66,7 +66,6 @@ int JanusFtl::Init(janus_callbacks* callback, const char* config_path)
     metadataReportInterval = configuration->GetServiceConnectionMetadataReportInterval();
     watchdog = std::make_unique<Watchdog>(configuration->GetServiceConnectionMetadataReportInterval());
 
-
     initPreviewGenerators();
 
     initOrchestratorConnection();

--- a/src/JanusFtl.h
+++ b/src/JanusFtl.h
@@ -19,6 +19,7 @@
 #include "Utilities/FtlTypes.h"
 #include "Utilities/JanssonPtr.h"
 #include "Utilities/Result.h"
+#include "Utilities/Watchdog.h"
 
 extern "C"
 {
@@ -114,7 +115,7 @@ private:
     std::shared_ptr<ServiceConnection> serviceConnection;
     std::unordered_map<VideoCodecKind, std::unique_ptr<PreviewGenerator>> previewGenerators;
     uint32_t maxAllowedBitsPerSecond = 0;
-    uint32_t metadataReportIntervalMs = 0;
+    std::chrono::milliseconds metadataReportInterval = std::chrono::milliseconds::min();
     uint16_t minMediaPort = 9000; // TODO: Migrate to Configuration
     uint16_t maxMediaPort = 10000; // TODO: Migrate to Configuration
     std::atomic<bool> isStopping = false;
@@ -122,6 +123,7 @@ private:
     std::future<void> serviceReportThreadEndedFuture;
     std::mutex threadShutdownMutex;
     std::condition_variable threadShutdownConditionVariable;
+    std::unique_ptr<Watchdog> watchdog;
     // Stream/Session/Relay data
     std::shared_mutex streamDataMutex; // Covers shared access to streams and sessions
     std::unordered_map<ftl_channel_id_t, ActiveStream> streams;

--- a/src/Utilities/Watchdog.cpp
+++ b/src/Utilities/Watchdog.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file Watchdog.cpp
+ * @author Daniel Stiner (danstiner@gmail.com)
+ * @version 0.1
+ * @date 2021-03-04
+ * 
+ * @copyright Copyright (c) 2021 Daniel Stiner
+ * 
+ */
+
+#include "Watchdog.h"
+
+#include <cstdlib>
+#include <string>
+
+#if defined(SYSTEMD_WATCHDOG_SUPPORT)
+    #include <systemd/sd-daemon.h>    
+#endif
+
+#pragma region Public methods
+
+Watchdog::Watchdog(std::chrono::milliseconds serviceConnectionMetadataReportInterval) {
+    if (char* watchdogIntervalUsecEnv = std::getenv("WATCHDOG_USEC"))
+    {
+        enabled = true;
+        
+        uint64_t watchdogIntervalUsec = std::stoi(watchdogIntervalUsecEnv);
+        std::chrono::microseconds watchdogInterval = std::chrono::microseconds(watchdogIntervalUsec);
+
+        if (watchdogInterval / 2 < serviceConnectionMetadataReportInterval) {
+            auto watchdogMs = std::chrono::duration_cast<std::chrono::milliseconds>(watchdogInterval);
+            auto metadataMs = std::chrono::duration_cast<std::chrono::milliseconds>(serviceConnectionMetadataReportInterval);
+            spdlog::error(
+                "Watchdog interval should be at least twice the metadata reporting interval: {}ms vs {}ms",
+                watchdogMs.count(),
+                metadataMs.count());
+        }
+    }
+}
+
+void Watchdog::Ready()
+{
+#if defined(SYSTEMD_WATCHDOG_SUPPORT)
+    if (enabled) {
+        // See https://www.freedesktop.org/software/systemd/man/sd_notify.html#READY=1
+        sd_notify(0, "READY=1");
+    }
+#endif
+}
+
+void Watchdog::IAmAlive()
+{
+#if defined(SYSTEMD_WATCHDOG_SUPPORT)
+    if (enabled) {
+        // See https://www.freedesktop.org/software/systemd/man/sd_notify.html#WATCHDOG=1
+        sd_notify(0, "WATCHDOG=1");
+    }
+#endif
+}
+#pragma endregion

--- a/src/Utilities/Watchdog.h
+++ b/src/Utilities/Watchdog.h
@@ -1,0 +1,32 @@
+/**
+ * @file Watchdog.h
+ * @author Daniel Stiner (danstiner@gmail.com)
+ * @version 0.1
+ * @date 2021-03-04
+ * 
+ * @copyright Copyright (c) 2021 Daniel Stiner
+ * 
+ * Support for watchdogs that can kill this service if it stops responding (e.g. deadlocks)
+ * 
+ * Currently supports systemd, for context see http://0pointer.de/blog/projects/watchdog.html
+ * 
+ */
+
+#pragma once
+
+#include <chrono>
+
+class Watchdog
+{
+public:
+    /* Constructor/Destructor */
+    Watchdog(std::chrono::milliseconds serviceConnectionMetadataReportInterva);
+
+    /* Public methods */
+    void Ready();
+    void IAmAlive();
+
+private:
+    /* Private fields */
+    bool enabled = false;
+};


### PR DESCRIPTION
Support for optional systemd watchdog integration to automatically restart the service if it is deadlocked. For context see http://0pointer.de/blog/projects/watchdog.html

Compile time support is auto enabled if you have the systemd dev headers available (Ubuntu package `libsystemd-dev`). Runtime support is auto enabled if you set the `WatchdogSec` systemd service option, this causes `WATCHDOG_USEC` to be passed which enables this watchdog integration.

Please be generous with the value for `WatchdogSec`. Strictly speaking the recommendation is to ping exactly every `WATCHDOG_USEC / 2`. To keep things simple I instead ping from the metadata reporting thread once per loop it does. This loop can take a variable amount of time as it does a lot of work. It loops through all streams to calculate stats, posts the metadata to Glimesh (including any retries it must do), and then sleeps for `FTL_SERVICE_METADATAREPORTINTERVALMS`. The benefit of this is if there are any deadlocks the metadata reporting thread basically always locks up so it's a great indicator of service health.

Recommended systemd options:
```
Type=notify
WatchdogSec=60s
Restart=on-failure
```

Optional options:
```
StartLimitInterval=5min
StartLimitBurst=4
StartLimitAction=reboot-force
```


