### PR TITLE
❣️ Fix use-after-free bug from using httplib::Client in non-thread-safe ways

### DIFF
--- a/src/ServiceConnections/GlimeshServiceConnection.cpp
+++ b/src/ServiceConnections/GlimeshServiceConnection.cpp
@@ -22,6 +22,7 @@ GlimeshServiceConnection::GlimeshServiceConnection(
     bool useHttps,
     std::string clientId,
     std::string clientSecret) : 
+    baseUri(fmt::format("{}://{}:{}", (useHttps ? "https" : "http"), hostname, port)),
     hostname(hostname),
     port(port),
     useHttps(useHttps),
@@ -33,9 +34,7 @@ GlimeshServiceConnection::GlimeshServiceConnection(
 #pragma region ServiceConnection
 void GlimeshServiceConnection::Init()
 {
-    std::stringstream baseUri;
-    baseUri << (useHttps ? "https" : "http") << "://" << hostname << ":" << port;
-    spdlog::info("Using Glimesh Service Connection @ {}", baseUri.str());
+    spdlog::info("Using Glimesh Service Connection @ {}", baseUri);
 
     // Try to auth
     ensureAuth(*getHttpClient());
@@ -219,7 +218,7 @@ Result<void> GlimeshServiceConnection::SendJpegPreviewImage(
 
 #pragma region Private methods
 std::unique_ptr<httplib::Client> GlimeshServiceConnection::getHttpClient() {
-    return std::make_unique<httplib::Client>(hostname, port);
+    return std::make_unique<httplib::Client>(baseUri.c_str());
 }
 
 void GlimeshServiceConnection::ensureAuth(httplib::Client& httpClient)

--- a/src/ServiceConnections/GlimeshServiceConnection.cpp
+++ b/src/ServiceConnections/GlimeshServiceConnection.cpp
@@ -232,6 +232,7 @@ void GlimeshServiceConnection::ensureAuth(httplib::Client& httpClient)
         std::time_t currentTime = std::time(nullptr);
         if (currentTime < accessTokenExpirationTime)
         {
+            httpClient.set_bearer_token_auth(accessToken.c_str());
             return;
         }
     }
@@ -277,7 +278,6 @@ void GlimeshServiceConnection::ensureAuth(httplib::Client& httpClient)
                 spdlog::info("Received new access token, expires in {} - {} = {} seconds",
                     expirationTime, currentTime, (expirationTime - currentTime));
 
-                // Update HTTP client Authorization header
                 httpClient.set_bearer_token_auth(accessToken.c_str());
                 return;
             }

--- a/src/ServiceConnections/GlimeshServiceConnection.h
+++ b/src/ServiceConnections/GlimeshServiceConnection.h
@@ -50,7 +50,6 @@ private:
     /* Private members */
     const int MAX_RETRIES = 10;
     const int TIME_BETWEEN_RETRIES_MS = 3000;
-    httplib::Client httpClient;
     std::string hostname;
     uint16_t port;
     bool useHttps;
@@ -61,7 +60,7 @@ private:
     std::mutex authMutex;
 
     /* Private methods */
-    void ensureAuth();
+    void ensureAuth(httplib::Client& httpClient);
     JsonPtr runGraphQlQuery(std::string query, JsonPtr variables = nullptr, httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
     JsonPtr processGraphQlResponse(const httplib::Result& result);
     tm parseIso8601DateTime(std::string dateTimeString);

--- a/src/ServiceConnections/GlimeshServiceConnection.h
+++ b/src/ServiceConnections/GlimeshServiceConnection.h
@@ -60,6 +60,7 @@ private:
     std::mutex authMutex;
 
     /* Private methods */
+    std::unique_ptr<httplib::Client> getHttpClient();
     void ensureAuth(httplib::Client& httpClient);
     JsonPtr runGraphQlQuery(std::string query, JsonPtr variables = nullptr, httplib::MultipartFormDataItems fileData = httplib::MultipartFormDataItems());
     JsonPtr processGraphQlResponse(const httplib::Result& result);

--- a/src/ServiceConnections/GlimeshServiceConnection.h
+++ b/src/ServiceConnections/GlimeshServiceConnection.h
@@ -50,6 +50,7 @@ private:
     /* Private members */
     const int MAX_RETRIES = 10;
     const int TIME_BETWEEN_RETRIES_MS = 3000;
+    std::string baseUri;
     std::string hostname;
     uint16_t port;
     bool useHttps;

--- a/src/ServiceConnections/RestServiceConnection.cpp
+++ b/src/ServiceConnections/RestServiceConnection.cpp
@@ -24,7 +24,6 @@ RestServiceConnection::RestServiceConnection(
     std::string pathBase,
     std::string authToken)
 :
-    httpClient(getHostUrl(useHttps, hostname, port).c_str()),
     hostname(hostname),
     port(port),
     useHttps(useHttps),
@@ -177,6 +176,8 @@ std::string RestServiceConnection::relativeToAbsolutePath(std::string relativePa
 
 httplib::Result RestServiceConnection::runGetRequest(std::string path)
 {
+    httplib::Client httpClient(hostname, port);
+
     // Make the request, and retry if necessary
     int numRetries = 0;
     while (true)

--- a/src/ServiceConnections/RestServiceConnection.cpp
+++ b/src/ServiceConnections/RestServiceConnection.cpp
@@ -42,15 +42,6 @@ RestServiceConnection::RestServiceConnection(
             this->pathBase.push_back('/');
         }
     }
-
-    if (this->authToken.length() > 0)
-    {
-        httplib::Headers headers
-        {
-            {"Authorization", authToken}
-        };
-        httpClient.set_default_headers(headers);
-    }
 }
 #pragma endregion
 
@@ -162,6 +153,19 @@ Result<void> RestServiceConnection::SendJpegPreviewImage(
 #pragma endregion
 
 #pragma region Private methods
+std::unique_ptr<httplib::Client> RestServiceConnection::getHttpClientWithAuth() {
+    auto httpClient = std::make_unique<httplib::Client>(hostname, port);
+    if (this->authToken.length() > 0)
+    {
+        httplib::Headers headers
+        {
+            {"Authorization", authToken}
+        };
+        httpClient->set_default_headers(headers);
+    }
+    return httpClient;
+}
+
 std::string RestServiceConnection::getHostUrl(bool https, std::string hostname, uint16_t port)
 {
     return fmt::format("{}://{}:{}", (https ? "https" : "http"), hostname, port);
@@ -174,16 +178,18 @@ std::string RestServiceConnection::relativeToAbsolutePath(std::string relativePa
     return fmt::format("{}{}", pathBase, relativePath);
 }
 
+
+
 httplib::Result RestServiceConnection::runGetRequest(std::string path)
 {
-    httplib::Client httpClient(hostname, port);
+    std::unique_ptr<httplib::Client> httpClient = getHttpClientWithAuth();
 
     // Make the request, and retry if necessary
     int numRetries = 0;
     while (true)
     {
         std::string absolutePath = relativeToAbsolutePath(path);
-        httplib::Result response = httpClient.Get(absolutePath.c_str());
+        httplib::Result response = httpClient->Get(absolutePath.c_str());
         if (response && response.error() == httplib::Error::Success && response->status < 500)
         {
             return response;
@@ -213,6 +219,8 @@ httplib::Result RestServiceConnection::runGetRequest(std::string path)
 httplib::Result RestServiceConnection::runPostRequest(std::string path, JsonPtr body,
     httplib::MultipartFormDataItems fileData)
 {
+    std::unique_ptr<httplib::Client> httpClient = getHttpClientWithAuth();
+
     // Make the request, and retry if necessary
     int numRetries = 0;
     while (true)
@@ -222,18 +230,18 @@ httplib::Result RestServiceConnection::runPostRequest(std::string path, JsonPtr 
         {
             if (fileData.size() > 0)
             {
-                return httpClient.Post(absolutePath.c_str(), fileData);
+                return httpClient->Post(absolutePath.c_str(), fileData);
             }
             else if (body)
             {
                 char* bodyStr = json_dumps(body.get(), 0);
                 auto bodyString = std::string(bodyStr);
                 free(bodyStr);
-                return httpClient.Post(absolutePath.c_str(), bodyString, "application/json");
+                return httpClient->Post(absolutePath.c_str(), bodyString, "application/json");
             }
             else
             {
-                return httpClient.Post(absolutePath.c_str(), "", "text/plain");
+                return httpClient->Post(absolutePath.c_str(), "", "text/plain");
             }
         }();
 

--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -46,7 +46,6 @@ private:
     /* Private members */
     const int MAX_RETRIES = 5;
     const int TIME_BETWEEN_RETRIES_MS = 3000;
-    httplib::Client httpClient;
     std::string hostname;
     uint16_t port;
     bool useHttps;

--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -53,6 +53,7 @@ private:
     std::string authToken;
 
     /* Private methods */
+    std::unique_ptr<httplib::Client> getHttpClientWithAuth();
     std::string getHostUrl(bool https, std::string hostname, uint16_t port);
     std::string relativeToAbsolutePath(std::string relativePath);
     httplib::Result runGetRequest(std::string path);

--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -46,6 +46,7 @@ private:
     /* Private members */
     const int MAX_RETRIES = 5;
     const int TIME_BETWEEN_RETRIES_MS = 3000;
+    std::string baseUri;
     std::string hostname;
     uint16_t port;
     bool useHttps;
@@ -54,7 +55,6 @@ private:
 
     /* Private methods */
     std::unique_ptr<httplib::Client> getHttpClientWithAuth();
-    std::string getHostUrl(bool https, std::string hostname, uint16_t port);
     std::string relativeToAbsolutePath(std::string relativePath);
     httplib::Result runGetRequest(std::string path);
     httplib::Result runPostRequest(std::string path, JsonPtr body = nullptr,


### PR DESCRIPTION
We've been seeing some strange crashes that looked like memory corruption.

After some hunting around we think we've narrowed it down to using the class instance of `httplib::Client` from multiple threads in parallel.

Technically the client does have a request mutex, but that has two limitations:
1. Changing headers is not protected by the request mutex, we think this is leading to the memory corruption.
2. Only one request may be in-flight at a time with a single client, this is probably adding significant latency in some cases

The downside of this is that we establish a new connection for basically every request, but I think the latency that can add is minimal compared to the above downsides.

Verified the GlimeshServiceConnection still works using my homelab setup.