### PR TITLE
💨 Support compiling with clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 test/test
 core
 build/
+build-clang/
 builddir/
 subprojects/*
 !subprojects/*.wrap

--- a/src/FtlStream.cpp
+++ b/src/FtlStream.cpp
@@ -38,8 +38,7 @@ FtlStream::FtlStream(
     mediaMetadata(mediaMetadata),
     streamId(streamId),
     onClosed(onClosed),
-    onRtpPacket(onRtpPacket),
-    nackLostPackets(nackLostPackets)
+    onRtpPacket(onRtpPacket)
 {
     // Prepare stream data stores to accept packets from SSRCs specified by control handshake
     ssrcData.try_emplace(mediaMetadata.AudioSsrc);

--- a/src/FtlStream.h
+++ b/src/FtlStream.h
@@ -104,8 +104,6 @@ private:
     const ftl_stream_id_t streamId;
     const ClosedCallback onClosed;
     const RtpPacketCallback onRtpPacket;
-    const bool nackLostPackets;
-    bool stopping = false;
     // Stream data
     std::shared_mutex dataMutex;
     time_t startTime { 0 };

--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -673,7 +673,7 @@ void JanusFtl::serviceReportThreadBody(std::promise<void>&& threadEndedPromise)
         // wind up waiting forever on the connection thread due to it taking a lock in the
         // JanusFtl::ftlServerRtpPacket callback
         lock.lock();
-        for (const auto channelStreamPair : streamsStopped)
+        for (const auto& channelStreamPair : streamsStopped)
         {
             endStream(channelStreamPair.first, channelStreamPair.second, lock);
         }
@@ -1003,12 +1003,11 @@ ConnectionResult JanusFtl::onOrchestratorStreamRelay(ConnectionRelayPayload payl
                 };
         }
 
-        if (relayClients.count(payload.ChannelId) <= 0)
-        {
-            relayClients.insert_or_assign(payload.ChannelId, std::list<ActiveRelay>());
-        }
-        relayClients.at(payload.ChannelId).emplace_back(payload.ChannelId, payload.TargetHostname,
-            std::move(relayClient));
+        relayClients[payload.ChannelId].push_back(ActiveRelay {
+            .ChannelId = payload.ChannelId,
+            .TargetHostname = payload.TargetHostname,
+            .Client = std::move(relayClient),
+        });
         
         return ConnectionResult
         {

--- a/src/JanusFtl.h
+++ b/src/JanusFtl.h
@@ -116,8 +116,6 @@ private:
     std::unordered_map<VideoCodecKind, std::unique_ptr<PreviewGenerator>> previewGenerators;
     uint32_t maxAllowedBitsPerSecond = 0;
     std::chrono::milliseconds metadataReportInterval = std::chrono::milliseconds::min();
-    uint16_t minMediaPort = 9000; // TODO: Migrate to Configuration
-    uint16_t maxMediaPort = 10000; // TODO: Migrate to Configuration
     std::atomic<bool> isStopping = false;
     std::thread serviceReportThread;
     std::future<void> serviceReportThreadEndedFuture;

--- a/src/PreviewGenerators/H264PreviewGenerator.cpp
+++ b/src/PreviewGenerators/H264PreviewGenerator.cpp
@@ -37,7 +37,7 @@ std::vector<uint8_t> H264PreviewGenerator::GenerateJpegImage(
 
         // For fragmented types, start bits are special, they have some extra data in the NAL header
         // that we need to include.
-        if ((fragmentType == 28))
+        if (fragmentType == 28)
         {
             if (startBit)
             {

--- a/src/ServiceConnections/GlimeshServiceConnection.cpp
+++ b/src/ServiceConnections/GlimeshServiceConnection.cpp
@@ -24,8 +24,6 @@ GlimeshServiceConnection::GlimeshServiceConnection(
     std::string clientSecret) : 
     baseUri(fmt::format("{}://{}:{}", (useHttps ? "https" : "http"), hostname, port)),
     hostname(hostname),
-    port(port),
-    useHttps(useHttps),
     clientId(clientId),
     clientSecret(clientSecret)
 { }

--- a/src/ServiceConnections/GlimeshServiceConnection.h
+++ b/src/ServiceConnections/GlimeshServiceConnection.h
@@ -52,8 +52,6 @@ private:
     const int TIME_BETWEEN_RETRIES_MS = 3000;
     std::string baseUri;
     std::string hostname;
-    uint16_t port;
-    bool useHttps;
     std::string clientId;
     std::string clientSecret;
     std::string accessToken;

--- a/src/ServiceConnections/RestServiceConnection.cpp
+++ b/src/ServiceConnections/RestServiceConnection.cpp
@@ -26,8 +26,6 @@ RestServiceConnection::RestServiceConnection(
 :
     baseUri(fmt::format("{}://{}:{}", (useHttps ? "https" : "http"), hostname, port)),
     hostname(hostname),
-    port(port),
-    useHttps(useHttps),
     pathBase(pathBase),
     authToken(authToken)
 {

--- a/src/ServiceConnections/RestServiceConnection.h
+++ b/src/ServiceConnections/RestServiceConnection.h
@@ -48,8 +48,6 @@ private:
     const int TIME_BETWEEN_RETRIES_MS = 3000;
     std::string baseUri;
     std::string hostname;
-    uint16_t port;
-    bool useHttps;
     std::string pathBase;
     std::string authToken;
 


### PR DESCRIPTION
Splitting this off from what I'm working on.

No functional change, just handy because it compiles twice as fast and has better error messages.

test with `CC=clang CXX=clang++ meson build-clang && ninja -C build-clang`