### PR TITLE
📦 Hand RTP packets directly to JanusStream

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,8 +47,9 @@ sources = files([
     'src/FtlControlConnection.cpp',
     'src/FtlServer.cpp',
     'src/FtlStream.cpp',
-    'src/JanusSession.cpp',
     'src/JanusFtl.cpp',
+    'src/JanusSession.cpp',
+    'src/JanusStream.cpp',
     # Library entrypoint
     'src/entrypoint.cpp',
 ])

--- a/src/FtlControlConnection.h
+++ b/src/FtlControlConnection.h
@@ -80,7 +80,6 @@ private:
     FtlStream* ftlStream = nullptr;
     bool hmacRequested = false;
     bool isAuthenticated = false;
-    bool mediaPortRequested = false;
     bool isStreaming = false;
     ftl_channel_id_t channelId = 0;
     std::vector<std::byte> hmacPayload;

--- a/src/FtlServer.cpp
+++ b/src/FtlServer.cpp
@@ -454,7 +454,7 @@ void FtlServer::eventTerminateControlConnection(
         std::move(pendingControlConnections.at(event->Connection).first);
     pendingControlConnections.erase(event->Connection);
     dispatchAsyncCall(
-        [this, event, control = std::move(control)]() mutable
+        [event, control = std::move(control)]() mutable
         {
             control->Stop(event->ResponseCode);
         });

--- a/src/FtlServer.cpp
+++ b/src/FtlServer.cpp
@@ -559,7 +559,7 @@ void FtlServer::eventStreamIdAssigned(std::shared_ptr<FtlServerStreamIdAssignedE
             auto stream = std::make_shared<FtlStream>(
                 std::move(control), std::move(mediaTransport), event->Metadata, event->StreamId,
                 std::bind(&FtlServer::onStreamClosed, this, std::placeholders::_1),
-                [rtpPacketSink](ftl_channel_id_t channelId, ftl_stream_id_t steamId, const std::vector<std::byte> packet)
+                [rtpPacketSink](const std::vector<std::byte> packet)
                 {
                     rtpPacketSink->SendRtpPacket(packet);
                 });

--- a/src/FtlServer.h
+++ b/src/FtlServer.h
@@ -9,6 +9,7 @@
 
 #include "FtlControlConnection.h"
 #include "FtlStream.h"
+#include "RtpPacketSink.h"
 #include "Utilities/FtlTypes.h"
 #include "Utilities/Result.h"
 
@@ -37,12 +38,17 @@ class ConnectionTransport;
 class FtlServer
 {
 public:
+    /* Public types */
+    struct StartedStreamInfo {
+        ftl_stream_id_t StreamId;
+        std::shared_ptr<RtpPacketSink> PacketSink;
+    };
+
     /* Callback types */
     using RequestKeyCallback = std::function<Result<std::vector<std::byte>>(ftl_channel_id_t)>;
     using StreamStartedCallback = 
-        std::function<Result<ftl_stream_id_t>(ftl_channel_id_t, MediaMetadata)>;
+        std::function<Result<StartedStreamInfo>(ftl_channel_id_t, MediaMetadata)>;
     using StreamEndedCallback = std::function<void(ftl_channel_id_t, ftl_stream_id_t)>;
-    using RtpPacketCallback = FtlStream::RtpPacketCallback;
 
     /* Constructor/Destructor */
     FtlServer(
@@ -51,7 +57,6 @@ public:
         RequestKeyCallback onRequestKey,
         StreamStartedCallback onStreamStarted,
         StreamEndedCallback onStreamEnded,
-        RtpPacketCallback onRtpPacket,
         uint16_t minMediaPort = DEFAULT_MEDIA_MIN_PORT,
         uint16_t maxMediaPort = DEFAULT_MEDIA_MAX_PORT);
     ~FtlServer() = default;
@@ -173,6 +178,7 @@ private:
         ftl_stream_id_t StreamId;
         MediaMetadata Metadata;
         in_addr TargetAddr;
+        std::shared_ptr<RtpPacketSink> PacketSink;
     };
     struct FtlServerStreamStartedEvent : public FtlServerEvent
     {
@@ -211,7 +217,6 @@ private:
     const RequestKeyCallback onRequestKey;
     const StreamStartedCallback onStreamStarted;
     const StreamEndedCallback onStreamEnded;
-    const RtpPacketCallback onRtpPacket;
     // Media ports
     const uint16_t minMediaPort;
     const uint16_t maxMediaPort;

--- a/src/FtlStream.cpp
+++ b/src/FtlStream.cpp
@@ -580,7 +580,7 @@ void FtlStream::processAudioVideoRtpPacket(const std::vector<std::byte>& rtpPack
     if (onRtpPacket)
     {
         dataLock.unlock(); // Unlock while we call out
-        onRtpPacket(GetChannelId(), streamId, rtpPacket);
+        onRtpPacket(rtpPacket);
         dataLock.lock();
     }
 }

--- a/src/FtlStream.h
+++ b/src/FtlStream.h
@@ -33,8 +33,7 @@ class FtlStream
 public:
     /* Public types */
     using ClosedCallback = std::function<void(FtlStream*)>;
-    using RtpPacketCallback = std::function<void(
-        ftl_channel_id_t, ftl_stream_id_t, const std::vector<std::byte>&)>;
+    using RtpPacketCallback = std::function<void(const std::vector<std::byte>&)>;
     struct FtlStreamStats
     {
         time_t StartTime;

--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -43,9 +43,7 @@ JanusFtl::JanusFtl(
         std::bind(&JanusFtl::ftlServerStreamStarted, this, std::placeholders::_1,
             std::placeholders::_2),
         std::bind(&JanusFtl::ftlServerStreamEnded, this, std::placeholders::_1,
-            std::placeholders::_2),
-        std::bind(&JanusFtl::ftlServerRtpPacket, this, std::placeholders::_1,
-            std::placeholders::_2, std::placeholders::_3));
+            std::placeholders::_2));
 }
 #pragma endregion
 
@@ -268,13 +266,13 @@ void JanusFtl::DestroySession(janus_plugin_session* handle, int* error)
         // If session is watching an active stream, remove it
         if (streams.count(channelId) > 0)
         {
-            ActiveStream& watchingStream = streams[channelId];
-            watchingStream.ViewerSessions.erase(session.Session.get());
+            std::shared_ptr<JanusStream>& watchingStream = streams[channelId];
+            watchingStream->RemoveViewerSession(session.Session.get());
 
             // If we're an Edge node and there are no more viewers for this channel, we can
             // unsubscribe.
             if ((configuration->GetNodeKind() == NodeKind::Edge) &&
-                (watchingStream.ViewerSessions.size() == 0))
+                (watchingStream->GetViewerCount() == 0))
             {
                 orchestratorUnsubscribe = true;
             }
@@ -337,7 +335,8 @@ Result<std::vector<std::byte>> JanusFtl::ftlServerRequestKey(ftl_channel_id_t ch
     return serviceConnection->GetHmacKey(channelId);
 }
 
-Result<ftl_stream_id_t> JanusFtl::ftlServerStreamStarted(ftl_channel_id_t channelId,
+Result<FtlServer::StartedStreamInfo> JanusFtl::ftlServerStreamStarted(
+    ftl_channel_id_t channelId,
     MediaMetadata mediaMetadata)
 {
     std::unique_lock lock(streamDataMutex);
@@ -346,37 +345,31 @@ Result<ftl_stream_id_t> JanusFtl::ftlServerStreamStarted(ftl_channel_id_t channe
     Result<ftl_stream_id_t> startResult = serviceConnection->StartStream(channelId);
     if (startResult.IsError)
     {
-        return startResult;
+        return Result<FtlServer::StartedStreamInfo>::Error(startResult.ErrorMessage);
     }
     ftl_stream_id_t streamId = startResult.Value;
 
     // Stop any existing streams on this channel
     if (streams.count(channelId) > 0)
     {
-        const ActiveStream& activeStream = streams[channelId];
+        const auto& stream = streams.at(channelId);
         spdlog::info("Existing Stream {} exists for Channel {} - stopping...",
-            activeStream.StreamId, channelId);
-        ftlServer->StopStream(activeStream.ChannelId, activeStream.StreamId);
-        endStream(activeStream.ChannelId, activeStream.StreamId, lock);
+            stream->GetStreamId(), channelId);
+        ftlServer->StopStream(stream->GetChannelId(), stream->GetStreamId());
+        endStream(stream->GetChannelId(), stream->GetStreamId(), lock);
     }
 
     // Insert new stream
-    streams.insert_or_assign(channelId, ActiveStream
-    {
-        .ChannelId = channelId,
-        .StreamId = streamId,
-        .Metadata = mediaMetadata,
-        .ViewerSessions = {},
-    });
+    auto stream = std::make_shared<JanusStream>(channelId, streamId, mediaMetadata);
+    streams[channelId] = stream;
 
     // Move any pending viewer sessions over
     if (pendingViewerSessions.count(channelId) > 0)
     {
         for (const auto& pendingSession : pendingViewerSessions[channelId])
         {
-            streams[channelId].ViewerSessions.insert(pendingSession);
-            sendJsep(sessions[pendingSession->GetJanusPluginSessionHandle()], streams[channelId],
-                nullptr);
+            stream->AddViewerSession(pendingSession);
+            sendJsep(sessions[pendingSession->GetJanusPluginSessionHandle()], *stream, nullptr);
         }
         pendingViewerSessions.erase(channelId);
     }
@@ -397,43 +390,16 @@ Result<ftl_stream_id_t> JanusFtl::ftlServerStreamStarted(ftl_channel_id_t channe
 
     spdlog::info("Registered new stream: Channel {} / Stream {}.", channelId, streamId);
 
-    return Result<ftl_stream_id_t>::Success(streamId);
+    return Result<FtlServer::StartedStreamInfo>::Success(FtlServer::StartedStreamInfo {
+        .StreamId = streamId,
+        .PacketSink = stream,
+    });
 }
 
 void JanusFtl::ftlServerStreamEnded(ftl_channel_id_t channelId, ftl_stream_id_t streamId)
 {
     std::unique_lock lock(streamDataMutex);
     endStream(channelId, streamId, lock);
-}
-
-void JanusFtl::ftlServerRtpPacket(ftl_channel_id_t channelId, ftl_stream_id_t streamId,
-    const std::vector<std::byte>& packetData)
-{
-    std::shared_lock lock(streamDataMutex);
-    if (streams.count(channelId) <= 0)
-    {
-        spdlog::error("Packet received for unexpected channel {}", channelId);
-        return;
-    }
-    const ActiveStream& stream = streams[channelId];
-    if (stream.StreamId != streamId)
-    {
-        spdlog::error("Packet received for channel {} had an unexpected stream ID: {}, expected {}",
-            channelId, streamId, stream.StreamId);
-        return;
-    }
-    for (const auto& session : stream.ViewerSessions)
-    {
-        session->SendRtpPacket(packetData, stream.Metadata);
-    }
-
-    if (relayClients.count(channelId) > 0)
-    {
-        for (const auto& relay : relayClients.at(channelId))
-        {
-            relay.Client->RelayPacket(packetData);
-        }
-    }
 }
 
 void JanusFtl::initPreviewGenerators()
@@ -563,8 +529,8 @@ void JanusFtl::serviceReportThreadBody(std::promise<void>&& threadEndedPromise)
             {
                 continue;
             }
-            metadataByChannel.try_emplace(channelId, streams.at(channelId).Metadata);
-            viewersByChannel.try_emplace(channelId, streams.at(channelId).ViewerSessions.size());
+            metadataByChannel.try_emplace(channelId, streams.at(channelId)->GetMetadata());
+            viewersByChannel.try_emplace(channelId, streams.at(channelId)->GetViewerCount());
         }
         lock.unlock();
 
@@ -657,7 +623,7 @@ void JanusFtl::serviceReportThreadBody(std::promise<void>&& threadEndedPromise)
         // wind up waiting forever on the connection thread due to it taking a lock in the
         // JanusFtl::ftlServerRtpPacket callback
         lock.lock();
-        for (const auto channelStreamPair : streamsStopped)
+        for (const auto& channelStreamPair : streamsStopped)
         {
             endStream(channelStreamPair.first, channelStreamPair.second, lock);
         }
@@ -673,50 +639,36 @@ void JanusFtl::endStream(ftl_channel_id_t channelId, ftl_stream_id_t streamId,
             streamId);
         return;
     }
-    const ActiveStream& activeStream = streams[channelId];
-    if (activeStream.StreamId != streamId)
+    const std::shared_ptr<JanusStream>& stream = streams.at(channelId);
+    if (stream->GetStreamId() != streamId)
     {
         spdlog::error("Stream ended from channel {} had unexpected stream id {}, expected {}",
-            channelId, streamId, activeStream.StreamId);
+            channelId, streamId, stream->GetStreamId());
         return;
     }
 
     // Reset any existing viewers to a pending state
-    if (pendingViewerSessions.count(channelId) == 0)
-    {
-        pendingViewerSessions.insert_or_assign(channelId, std::unordered_set<JanusSession*>());
-    }
-    pendingViewerSessions[channelId].insert(activeStream.ViewerSessions.begin(),
-        activeStream.ViewerSessions.end());
+    auto viewerSessions = stream->RemoveAllViewerSessions();
+    pendingViewerSessions[channelId].insert(viewerSessions.begin(), viewerSessions.end());
     // TODO: Tell viewers stream is offline.
 
     // If we are configured as an Ingest node, notify the Orchestrator that a stream has ended.
     if ((configuration->GetNodeKind() == NodeKind::Ingest) && (orchestrationClient != nullptr))
     {
         spdlog::info("Unpublishing channel {} / stream {} from Orchestrator",
-            activeStream.ChannelId, activeStream.StreamId);
+            stream->GetChannelId(), stream->GetStreamId());
         orchestrationClient->SendStreamPublish(ConnectionPublishPayload
             {
                 .IsPublish = false,
-                .ChannelId = activeStream.ChannelId,
-                .StreamId = activeStream.StreamId,
+                .ChannelId = stream->GetChannelId(),
+                .StreamId = stream->GetStreamId(),
             });
     }
 
-    // If relays exist for this stream, stop them
-    if (relayClients.count(channelId) > 0)
-    {
-        for (const auto& relay : relayClients.at(channelId))
-        {
-            spdlog::info("Stopping relay for channel {} / stream {} -> {}...", activeStream.ChannelId,
-                activeStream.StreamId, relay.TargetHostname);
-            relay.Client->Stop();
-        }
-        relayClients.erase(channelId);
-    }
+    stream->StopRelays();
 
-    spdlog::info("Stream ended. Channel {} / stream {}", activeStream.ChannelId,
-        activeStream.StreamId);
+    spdlog::info("Stream ended. Channel {} / stream {}",
+        stream->GetChannelId(), stream->GetStreamId());
 
     serviceConnection->EndStream(streamId);
     streams.erase(channelId);
@@ -822,17 +774,17 @@ janus_plugin_result* JanusFtl::handleWatchMessage(ActiveSession& session, JsonPt
     }
 
     // Otherwise, we've got a live stream!
-    ActiveStream& stream = streams[channelId];
+    auto& stream = streams.at(channelId);
 
     // TODO allow user to request ICE restart (new offer)
 
     // TODO if they're already watching, handle it
 
     // Set this session as a viewer
-    stream.ViewerSessions.insert(session.Session.get());
+    stream->AddViewerSession(session.Session.get());
 
     // Send the JSEP to initiate the media connection
-    sendJsep(session, stream, transaction);
+    sendJsep(session, *stream, transaction);
 
     return janus_plugin_result_new(JANUS_PLUGIN_OK_WAIT, NULL, NULL);
 }
@@ -843,7 +795,7 @@ janus_plugin_result* JanusFtl::handleStartMessage(ActiveSession& session, JsonPt
     return janus_plugin_result_new(JANUS_PLUGIN_OK_WAIT, NULL, NULL);
 }
 
-int JanusFtl::sendJsep(const ActiveSession& session, const ActiveStream& stream, char* transaction)
+int JanusFtl::sendJsep(const ActiveSession& session, const JanusStream& stream, char* transaction)
 {
     // Prepare JSEP payload
     std::string sdpOffer = generateSdpOffer(session, stream);
@@ -865,7 +817,7 @@ int JanusFtl::sendJsep(const ActiveSession& session, const ActiveStream& stream,
         jsepPtr.get());
 }
 
-std::string JanusFtl::generateSdpOffer(const ActiveSession& session, const ActiveStream& stream)
+std::string JanusFtl::generateSdpOffer(const ActiveSession& session, const JanusStream& stream)
 {
     // https://tools.ietf.org/html/rfc4566
 
@@ -875,14 +827,14 @@ std::string JanusFtl::generateSdpOffer(const ActiveSession& session, const Activ
     offerStream <<  
         "v=0\r\n" <<
         "o=- " << session.Session->GetSdpSessionId() << " " << session.Session->GetSdpVersion() << " IN IP4 127.0.0.1\r\n" <<
-        "s=Channel " << stream.ChannelId << "\r\n";
+        "s=Channel " << stream.GetChannelId() << "\r\n";
 
     // Audio media description
-    if (stream.Metadata.HasAudio)
+    if (stream.GetMetadata().HasAudio)
     {
-        std::string audioPayloadType = std::to_string(stream.Metadata.AudioPayloadType);
+        std::string audioPayloadType = std::to_string(stream.GetMetadata().AudioPayloadType);
         std::string audioCodec = 
-            SupportedAudioCodecs::AudioCodecString(stream.Metadata.AudioCodec);
+            SupportedAudioCodecs::AudioCodecString(stream.GetMetadata().AudioCodec);
         offerStream <<  
             "m=audio 1 RTP/SAVPF " << audioPayloadType << "\r\n" <<
             "c=IN IP4 1.1.1.1\r\n" <<
@@ -892,11 +844,11 @@ std::string JanusFtl::generateSdpOffer(const ActiveSession& session, const Activ
     }
 
     // Video media description
-    if (stream.Metadata.HasVideo)
+    if (stream.GetMetadata().HasVideo)
     {
-        std::string videoPayloadType = std::to_string(stream.Metadata.VideoPayloadType);
+        std::string videoPayloadType = std::to_string(stream.GetMetadata().VideoPayloadType);
         std::string videoCodec = 
-            SupportedVideoCodecs::VideoCodecString(stream.Metadata.VideoCodec);
+            SupportedVideoCodecs::VideoCodecString(stream.GetMetadata().VideoCodec);
         offerStream <<  
             "m=video 1 RTP/SAVPF " << videoPayloadType << "\r\n" <<
             "c=IN IP4 1.1.1.1\r\n" <<
@@ -946,7 +898,7 @@ ConnectionResult JanusFtl::onOrchestratorStreamRelay(ConnectionRelayPayload payl
             payload.TargetHostname);
 
         // Do we have an active stream?
-        if (streams.count(payload.ChannelId) <= 0)
+        if (!streams.contains(payload.ChannelId))
         {
             spdlog::error("Orchestrator requested a relay for channel that is not streaming."
                 "Target hostname: {}, Channel ID: {}", payload.TargetHostname, payload.ChannelId);
@@ -955,7 +907,7 @@ ConnectionResult JanusFtl::onOrchestratorStreamRelay(ConnectionRelayPayload payl
                     .IsSuccess = false,
                 };
         }
-        ActiveStream& activeStream = streams[payload.ChannelId];
+        auto& stream = streams.at(payload.ChannelId);
 
         // Start the relay now!
         auto relayClient = std::make_unique<FtlClient>(payload.TargetHostname, payload.ChannelId,
@@ -964,18 +916,18 @@ ConnectionResult JanusFtl::onOrchestratorStreamRelay(ConnectionRelayPayload payl
             {
                 .VendorName = "janus-ftl-plugin",
                 .VendorVersion = "0.0.0", // TODO: Versioning
-                .HasVideo = activeStream.Metadata.HasVideo,
+                .HasVideo = stream->GetMetadata().HasVideo,
                 .VideoCodec = SupportedVideoCodecs::VideoCodecString(
-                    activeStream.Metadata.VideoCodec),
-                .VideoHeight = activeStream.Metadata.VideoHeight,
-                .VideoWidth = activeStream.Metadata.VideoWidth,
-                .VideoPayloadType = activeStream.Metadata.VideoPayloadType,
-                .VideoIngestSsrc = activeStream.Metadata.VideoSsrc,
-                .HasAudio = activeStream.Metadata.HasAudio,
+                    stream->GetMetadata().VideoCodec),
+                .VideoHeight = stream->GetMetadata().VideoHeight,
+                .VideoWidth = stream->GetMetadata().VideoWidth,
+                .VideoPayloadType = stream->GetMetadata().VideoPayloadType,
+                .VideoIngestSsrc = stream->GetMetadata().VideoSsrc,
+                .HasAudio = stream->GetMetadata().HasAudio,
                 .AudioCodec = SupportedAudioCodecs::AudioCodecString(
-                    activeStream.Metadata.AudioCodec),
-                .AudioPayloadType = activeStream.Metadata.AudioPayloadType,
-                .AudioIngestSsrc = activeStream.Metadata.AudioSsrc,
+                    stream->GetMetadata().AudioCodec),
+                .AudioPayloadType = stream->GetMetadata().AudioPayloadType,
+                .AudioIngestSsrc = stream->GetMetadata().AudioSsrc,
             });
         if (connectResult.IsError)
         {
@@ -987,12 +939,7 @@ ConnectionResult JanusFtl::onOrchestratorStreamRelay(ConnectionRelayPayload payl
                 };
         }
 
-        if (relayClients.count(payload.ChannelId) <= 0)
-        {
-            relayClients.insert_or_assign(payload.ChannelId, std::list<ActiveRelay>());
-        }
-        relayClients.at(payload.ChannelId).emplace_back(payload.ChannelId, payload.TargetHostname,
-            std::move(relayClient));
+        stream->AddRelayClient(payload.TargetHostname, std::move(relayClient));
         
         return ConnectionResult
         {
@@ -1005,39 +952,28 @@ ConnectionResult JanusFtl::onOrchestratorStreamRelay(ConnectionRelayPayload payl
             "Channel {}, Stream {}, Target: {}", payload.ChannelId, payload.StreamId,
             payload.TargetHostname);
 
-        // Remove and stop matching relays
-        int numRelaysRemoved = 0;
-        if (relayClients.count(payload.ChannelId) > 0)
+            
+        // Do we have an active stream?
+        if (streams.contains(payload.ChannelId))
         {
-            for (auto it = relayClients.at(payload.ChannelId).begin();
-                it != relayClients.at(payload.ChannelId).end();)
-            {
-                ActiveRelay& relay = *it;
-                if ((relay.ChannelId == payload.ChannelId) &&
-                    (relay.TargetHostname == payload.TargetHostname))
-                {
-                    relay.Client->Stop();
-                    it = relayClients.at(payload.ChannelId).erase(it);
-                    ++numRelaysRemoved;
-                }
-                else
-                {
-                    ++it;
-                }
-            }
+            spdlog::warn("Orchestrator requested to stop a relay for channel that is not streaming."
+                "Target hostname: {}, Channel ID: {}", payload.TargetHostname, payload.ChannelId);
+            return ConnectionResult { .IsSuccess = true };
         }
-
-        if (numRelaysRemoved == 0)
+        auto& stream = streams.at(payload.ChannelId);
+        if (stream->GetStreamId() != payload.StreamId)
+        {
+            spdlog::warn("Orchestrator requested to stop a relay for a stream that no longer exists: "
+                "Channel {}, Stream {}", payload.ChannelId, payload.StreamId);
+            return ConnectionResult { .IsSuccess = true };
+        }
+        if (!stream->StopRelay(payload.TargetHostname))
         {
             spdlog::warn("Orchestrator requested to stop non-existant relay: "
                 "Channel {}, Stream {}, Target: {}", payload.ChannelId, payload.StreamId,
                 payload.TargetHostname);
         }
-
-        return ConnectionResult
-        {
-            .IsSuccess = true,
-        };
+        return ConnectionResult { .IsSuccess = true };
     }
 }
 #pragma endregion Private methods

--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -954,7 +954,7 @@ ConnectionResult JanusFtl::onOrchestratorStreamRelay(ConnectionRelayPayload payl
 
             
         // Do we have an active stream?
-        if (streams.contains(payload.ChannelId))
+        if (!streams.contains(payload.ChannelId))
         {
             spdlog::warn("Orchestrator requested to stop a relay for channel that is not streaming."
                 "Target hostname: {}, Channel ID: {}", payload.TargetHostname, payload.ChannelId);

--- a/src/JanusStream.cpp
+++ b/src/JanusStream.cpp
@@ -81,8 +81,10 @@ size_t JanusStream::StopRelay(const std::string& targetHostname)
             }
         }
     }
-    for (Relay& relay : relays)
+    for (Relay& relay : removedRelays)
     {
+        spdlog::info("Stopping relay for channel {} / stream {} -> {}...",
+            channelId, streamId, relay.TargetHostname);
          relay.Client->Stop();
     }
     return removedRelays.size();
@@ -93,8 +95,8 @@ void JanusStream::StopRelays()
     std::lock_guard lock(mutex);
     for (const auto& relay : relays)
     {
-        spdlog::info("Stopping relay for channel {} / stream {} -> {}...", channelId,
-            streamId, relay.TargetHostname);
+        spdlog::info("Stopping relay for channel {} / stream {} -> {}...",
+            channelId, streamId, relay.TargetHostname);
         relay.Client->Stop();
     }
     relays.clear();

--- a/src/JanusStream.cpp
+++ b/src/JanusStream.cpp
@@ -92,14 +92,17 @@ size_t JanusStream::StopRelay(const std::string& targetHostname)
 
 void JanusStream::StopRelays()
 {
-    std::lock_guard lock(mutex);
-    for (const auto& relay : relays)
+    std::list<Relay> removedRelays;
+    {
+        std::lock_guard lock(mutex);
+        relays.swap(removedRelays);
+    }
+    for (const auto& relay : removedRelays)
     {
         spdlog::info("Stopping relay for channel {} / stream {} -> {}...",
             channelId, streamId, relay.TargetHostname);
         relay.Client->Stop();
     }
-    relays.clear();
 }
 
 #pragma endregion

--- a/src/JanusStream.cpp
+++ b/src/JanusStream.cpp
@@ -49,9 +49,9 @@ size_t JanusStream::RemoveViewerSession(JanusSession* session)
 std::unordered_set<JanusSession*> JanusStream::RemoveAllViewerSessions()
 {
     std::lock_guard lock(mutex);
-    std::unordered_set<JanusSession*> viewerSessions;
-    viewerSessions.swap(viewerSessions);
-    return viewerSessions;
+    std::unordered_set<JanusSession*> removedSessions;
+    viewerSessions.swap(removedSessions);
+    return removedSessions;
 }
 
 size_t JanusStream::GetViewerCount() const

--- a/src/JanusStream.cpp
+++ b/src/JanusStream.cpp
@@ -60,12 +60,12 @@ size_t JanusStream::GetViewerCount() const
     return viewerSessions.size();
 }
 
-void JanusStream::AddRelayClient(const std::string targetHostname, std::unique_ptr<FtlClient> client)
+void JanusStream::AddRelayClient(const std::string targetHostname,
+    std::unique_ptr<FtlClient> client)
 {
     std::lock_guard lock(mutex);
     relays.push_back(Relay { .TargetHostname = targetHostname, .Client = std::move(client) });
 }
-
 
 size_t JanusStream::StopRelay(const std::string& targetHostname)
 {

--- a/src/JanusStream.cpp
+++ b/src/JanusStream.cpp
@@ -1,0 +1,115 @@
+/**
+ * @file JanusStream.h
+ * @author Daniel Stiner (danstiner@gmail.com)
+ * @date 2021-03-10
+ * @copyright Copyright (c) 2021 Daniel Stiner
+ */
+
+#include "JanusStream.h"
+
+#pragma region Constructor/Destructor
+JanusStream::JanusStream(
+    ftl_channel_id_t channelId,
+    ftl_stream_id_t streamId,
+    MediaMetadata mediaMetadata) :
+    channelId(channelId),
+    streamId(streamId),
+    mediaMetadata(mediaMetadata)
+{ }
+#pragma endregion
+
+#pragma region Public methods
+void JanusStream::SendRtpPacket(const std::vector<std::byte>& packet)
+{
+    std::lock_guard lock(mutex);
+
+    for (const auto& session : viewerSessions)
+    {
+        session->SendRtpPacket(packet, mediaMetadata);
+    }
+
+    for (const auto& relay : relays)
+    {
+        relay.Client->RelayPacket(packet);
+    }
+}
+
+void JanusStream::AddViewerSession(JanusSession* session)
+{
+    std::lock_guard lock(mutex);
+    viewerSessions.insert(session);
+}
+
+size_t JanusStream::RemoveViewerSession(JanusSession* session)
+{
+    std::lock_guard lock(mutex);
+    return viewerSessions.erase(session);
+}
+
+std::unordered_set<JanusSession*> JanusStream::RemoveAllViewerSessions()
+{
+    std::lock_guard lock(mutex);
+    std::unordered_set<JanusSession*> viewerSessions;
+    viewerSessions.swap(viewerSessions);
+    return viewerSessions;
+}
+
+size_t JanusStream::GetViewerCount() const
+{
+    return viewerSessions.size();
+}
+
+void JanusStream::AddRelayClient(const std::string targetHostname, std::unique_ptr<FtlClient> client)
+{
+    std::lock_guard lock(mutex);
+    relays.push_back(Relay { .TargetHostname = targetHostname, .Client = std::move(client) });
+}
+
+
+size_t JanusStream::StopRelay(const std::string& targetHostname)
+{
+    std::lock_guard lock(mutex);
+    size_t numRelaysRemoved = 0;
+    for (auto it = relays.begin();
+        it != relays.end();)
+    {
+        Relay& relay = *it;
+        if (relay.TargetHostname == targetHostname) {
+            relay.Client->Stop();
+            it = relays.erase(it);
+            ++numRelaysRemoved;
+        }
+    }
+    return numRelaysRemoved;
+}
+
+void JanusStream::StopRelays()
+{
+    std::lock_guard lock(mutex);
+    for (const auto& relay : relays)
+    {
+        spdlog::info("Stopping relay for channel {} / stream {} -> {}...", channelId,
+            streamId, relay.TargetHostname);
+        relay.Client->Stop();
+    }
+    relays.clear();
+}
+
+#pragma endregion
+
+#pragma region Getters/setters
+
+ftl_channel_id_t JanusStream::GetChannelId() const
+{
+    return channelId;
+}
+ftl_stream_id_t JanusStream::GetStreamId() const
+{
+    return streamId;
+}
+MediaMetadata JanusStream::GetMetadata() const
+{
+    return mediaMetadata;
+}
+
+#pragma endregion

--- a/src/JanusStream.cpp
+++ b/src/JanusStream.cpp
@@ -56,6 +56,7 @@ std::unordered_set<JanusSession*> JanusStream::RemoveAllViewerSessions()
 
 size_t JanusStream::GetViewerCount() const
 {
+    std::lock_guard lock(mutex);
     return viewerSessions.size();
 }
 

--- a/src/JanusStream.h
+++ b/src/JanusStream.h
@@ -55,5 +55,5 @@ private:
     MediaMetadata mediaMetadata;
     std::unordered_set<JanusSession*> viewerSessions;
     std::list<Relay> relays;
-    std::mutex mutex;
+    mutable std::mutex mutex;
 };

--- a/src/JanusStream.h
+++ b/src/JanusStream.h
@@ -1,0 +1,59 @@
+/**
+ * @file JanusStream.h
+ * @author Daniel Stiner (danstiner@gmail.com)
+ * @date 2021-03-10
+ * @copyright Copyright (c) 2021 Daniel Stiner
+ */
+
+#pragma once
+
+#include "FtlClient.h"
+#include "JanusSession.h"
+#include "RtpPacketSink.h"
+#include "Utilities/FtlTypes.h"
+
+#include <unordered_set>
+#include <vector>
+
+class JanusStream : public RtpPacketSink
+{
+public:
+    /* Constructor/Destructor */
+    JanusStream(
+        ftl_channel_id_t channelId,
+        ftl_stream_id_t streamId,
+        MediaMetadata mediaMetadata);
+
+    /* Public methods */
+    void SendRtpPacket(const std::vector<std::byte>& packet) override;
+
+    // Session methods
+    void AddViewerSession(JanusSession* session);
+    size_t RemoveViewerSession(JanusSession* session);
+    std::unordered_set<JanusSession*> RemoveAllViewerSessions();
+    size_t GetViewerCount() const;
+
+    // Relay client methods
+    void AddRelayClient(const std::string targetHostname, std::unique_ptr<FtlClient> client);
+    size_t StopRelay(const std::string& targetHostname);
+    void StopRelays();
+
+    /* Getters/Setters */
+    ftl_channel_id_t GetChannelId() const;
+    ftl_stream_id_t GetStreamId() const;
+    MediaMetadata GetMetadata() const;
+
+private:
+    struct Relay
+    {
+        std::string TargetHostname;
+        std::unique_ptr<FtlClient> Client;
+    };
+
+    ftl_channel_id_t channelId;
+    ftl_stream_id_t streamId;
+    MediaMetadata mediaMetadata;
+    std::unordered_set<JanusSession*> viewerSessions;
+    std::list<Relay> relays;
+    std::mutex mutex;
+};

--- a/src/RtpPacketSink.h
+++ b/src/RtpPacketSink.h
@@ -1,0 +1,19 @@
+/**
+ * @file RtpPacketSink.h
+ * @author Daniel Stiner (danstiner@gmail.com)
+ * @date 2021-03-10
+ * @copyright Copyright (c) 2021 Daniel Stiner
+ */
+
+#pragma once
+
+#include <vector>
+
+class RtpPacketSink
+{
+public:
+    virtual ~RtpPacketSink() {};
+
+    /* Public methods */
+    virtual void SendRtpPacket(const std::vector<std::byte>& packet) = 0;
+};


### PR DESCRIPTION
Going back and doing ebefe001a1f6a42cac2c1c8f7cf59db18fe50897 the right way this time.

This shortens the path for RTP packets to only require a single lock at the stream level.