### PR TITLE
💩 Do not disable build if systemd is missing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -62,8 +62,6 @@ spdlog_wrap = subproject('spdlog', default_options: ['default_library=static', '
 systemd_dep = dependency('libsystemd', required : get_option('systemd_watchdog_support'))
 if systemd_dep.found()
   add_project_arguments('-DSYSTEMD_WATCHDOG_SUPPORT', language: 'cpp') 
-else
-  systemd_dep = disabler()
 endif
 
 deps = [


### PR DESCRIPTION
I meant to make systemd an optional dependency, but I used meson's `disabler()` which actually recursively disables any parts of the build it is included in. So the main `.so` would not build if you didn't have libsystemd-dev installed.

Fixes #103 