### PR TITLE
🧪 Add FtlControlConnectionTest, add GH action for tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ on:
 
 jobs:
   build:
-
+    name: Build
     runs-on: ubuntu-latest
-
     steps:
     - name: Install Dependency Packages
       run: sudo apt update && sudo apt install libmicrohttpd-dev libjansson-dev libssl-dev libsofia-sip-ua-dev libglib2.0-dev libopus-dev libogg-dev libcurl4-openssl-dev liblua5.3-dev libconfig-dev pkg-config gengetopt libtool automake python3 python3-pip python3-setuptools python3-dev python3-wheel ninja-build libavcodec-dev libsystemd-dev
@@ -53,3 +52,21 @@ jobs:
         name: libjanus_ftl
         path: janus-ftl-plugin/build/libjanus_ftl.so
         if-no-files-found: error
+    - name: Upload Test Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: janus-ftl-plugin-test
+        path: janus-ftl-plugin/build/janus-ftl-plugin-test
+        if-no-files-found: error
+
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: janus-ftl-plugin-test
+    - name: Run Tests
+      run: chmod +x janus-ftl-plugin-test && ./janus-ftl-plugin-test

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,7 @@ sources = files([
 fmt_wrap = subproject('fmt', default_options: 'default_library=static')
 meson.override_dependency('fmt', fmt_wrap.get_variable('fmt_dep')) # Use our copy of fmt for spdlog
 spdlog_wrap = subproject('spdlog', default_options: ['default_library=static', 'compile_library=true', 'external_fmt=true'] )
+catch2_wrap = subproject('catch2')
 
 # Optional libsystemd dep for watchdog monitoring support
 systemd_dep = dependency('libsystemd', required : get_option('systemd_watchdog_support'))
@@ -112,13 +113,15 @@ test_incdirs = include_directories(
 )
 
 test_deps = [
-    subproject('spdlog').get_variable('spdlog_dep'),
-    subproject('catch2').get_variable('catch2_dep'),
+    fmt_wrap.get_variable('fmt_dep'),
+    spdlog_wrap.get_variable('spdlog_dep'),
+    catch2_wrap.get_variable('catch2_dep'),
 ]
 
 executable(
     'janus-ftl-plugin-test',
     test_sources,
+    cpp_pch: 'pch/janus_ftl_test_pch.h',
     dependencies: test_deps,
     include_directories: test_incdirs,
 )

--- a/meson.build
+++ b/meson.build
@@ -105,14 +105,22 @@ shared_library(
 test_sources = files([
     # Entrypoint
     'test/test.cpp',
+    # Unit tests
+    'test/unit/FtlControlConnectionUnitTests.cpp',
+    # Project sources
+    'src/FtlControlConnection.cpp',
+    'src/FtlStream.cpp',
+    'src/Utilities/Rtp.cpp',
 ])
 
 test_incdirs = include_directories(
-    './test',
-    './src',
+    './vendor/eventpp/include',
+    is_system: true,
 )
 
 test_deps = [
+    dependency('libssl'),
+    dependency('libcrypto'),
     fmt_wrap.get_variable('fmt_dep'),
     spdlog_wrap.get_variable('spdlog_dep'),
     catch2_wrap.get_variable('catch2_dep'),

--- a/pch/janus_ftl_test_pch.h
+++ b/pch/janus_ftl_test_pch.h
@@ -1,5 +1,5 @@
 /**
- * @file janus_ftl_pch.h
+ * @file janus_ftl_test_pch.h
  * @author Hayden McAfee (hayden@outlook.com)
  * @date 2021-03-18
  * @copyright Copyright (c) 2021 Hayden McAfee
@@ -7,3 +7,6 @@
 
 #include <fmt/core.h>
 #include <spdlog/spdlog.h>
+
+#define CATCH_CONFIG_ALL_PARTS
+#include <catch2/catch.hpp>

--- a/src/FtlControlConnection.h
+++ b/src/FtlControlConnection.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "FtlControlConnectionManager.h"
 #include "Utilities/FtlTypes.h"
 #include "Utilities/Result.h"
 
@@ -19,7 +20,6 @@
 
 // Forward declarations
 class ConnectionTransport;
-class FtlServer;
 class FtlStream;
 
 /**
@@ -55,7 +55,7 @@ public:
 
     /* Constructor/Destructor */
     FtlControlConnection(
-        FtlServer* ftlServer,
+        FtlControlConnectionManager* connectionManager,
         std::unique_ptr<ConnectionTransport> transport);
 
     /* Getters/Setters */
@@ -75,7 +75,7 @@ private:
     static constexpr int HMAC_PAYLOAD_SIZE = 128;
 
     /* Private fields */
-    FtlServer* const ftlServer;
+    FtlControlConnectionManager* const connectionManager;
     const std::unique_ptr<ConnectionTransport> transport;
     FtlStream* ftlStream = nullptr;
     bool hmacRequested = false;

--- a/src/FtlControlConnectionManager.h
+++ b/src/FtlControlConnectionManager.h
@@ -1,0 +1,42 @@
+/**
+ * @file ControlConnectionManager.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2021-03-18
+ * @copyright Copyright (c) 2021 Hayden McAfee
+ */
+
+#pragma once
+
+#include <arpa/inet.h>
+
+#include "Utilities/FtlTypes.h"
+
+// Forward declarations
+class FtlControlConnection;
+
+/**
+ * @brief A simple interface used for objects to handle instances of FtlControlConnection
+ */
+class FtlControlConnectionManager
+{
+public:
+    virtual ~FtlControlConnectionManager() = default;
+
+    /**
+     * @brief Called by FtlControlConnection when the control connection has stopped.
+     */
+    virtual void ControlConnectionStopped(FtlControlConnection* connection) = 0;
+
+    /**
+     * @brief Called by FtlControlConnection when it wants an HMAC key for a channel
+     */
+    virtual void ControlConnectionRequestedHmacKey(FtlControlConnection* connection,
+        ftl_channel_id_t channelId) = 0;
+
+    /**
+     * @brief Called by FtlControlConnection when it needs a media port assigned
+     */
+    virtual void ControlConnectionRequestedMediaPort(FtlControlConnection* connection,
+        ftl_channel_id_t channelId, MediaMetadata mediaMetadata, in_addr targetAddr) = 0;
+
+};

--- a/src/FtlServer.h
+++ b/src/FtlServer.h
@@ -60,43 +60,43 @@ public:
         StreamEndedCallback onStreamEnded,
         uint16_t minMediaPort = DEFAULT_MEDIA_MIN_PORT,
         uint16_t maxMediaPort = DEFAULT_MEDIA_MAX_PORT);
-    virtual ~FtlServer() = default;
+    ~FtlServer() = default;
 
     /* Public functions */
     /**
      * @brief Starts listening for FTL connections on a new thread.
      */
-    virtual void StartAsync();
+    void StartAsync();
 
     /**
      * @brief Stops listening for FTL connections.
      */
-    virtual void Stop();
+    void Stop();
 
     /* FtlControlConnectionManager implementation */
-    virtual void ControlConnectionStopped(FtlControlConnection* connection) override;
-    virtual void ControlConnectionRequestedHmacKey(FtlControlConnection* connection,
+    void ControlConnectionStopped(FtlControlConnection* connection) override;
+    void ControlConnectionRequestedHmacKey(FtlControlConnection* connection,
         ftl_channel_id_t channelId) override;
-    virtual void ControlConnectionRequestedMediaPort(FtlControlConnection* connection,
+    void ControlConnectionRequestedMediaPort(FtlControlConnection* connection,
         ftl_channel_id_t channelId, MediaMetadata mediaMetadata, in_addr targetAddr) override;
 
     /**
      * @brief Stops the stream with the specified channel ID and stream ID.
      * This will not fire the StreamEnded callback.
      */
-    virtual void StopStream(ftl_channel_id_t channelId, ftl_stream_id_t streamId);
+    void StopStream(ftl_channel_id_t channelId, ftl_stream_id_t streamId);
 
     /**
      * @brief Retrieves stats for all active streams
      */
-    virtual std::list<std::pair<std::pair<ftl_channel_id_t, ftl_stream_id_t>,
+    std::list<std::pair<std::pair<ftl_channel_id_t, ftl_stream_id_t>,
         std::pair<FtlStream::FtlStreamStats, FtlStream::FtlKeyframe>>>
         GetAllStatsAndKeyframes();
 
     /**
      * @brief Retrieves stats for the given stream
      */
-    virtual Result<FtlStream::FtlStreamStats> GetStats(ftl_channel_id_t channelId,
+    Result<FtlStream::FtlStreamStats> GetStats(ftl_channel_id_t channelId,
         ftl_stream_id_t streamId);
 
 private:

--- a/src/FtlServer.h
+++ b/src/FtlServer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "FtlControlConnectionManager.h"
 #include "FtlControlConnection.h"
 #include "FtlStream.h"
 #include "RtpPacketSink.h"
@@ -35,7 +36,7 @@ class ConnectionTransport;
  * @brief FtlServer manages ingest control and media connections, exposing the relevant stream
  * data for consumers to use.
  */
-class FtlServer
+class FtlServer : public FtlControlConnectionManager
 {
 public:
     /* Public types */
@@ -59,53 +60,43 @@ public:
         StreamEndedCallback onStreamEnded,
         uint16_t minMediaPort = DEFAULT_MEDIA_MIN_PORT,
         uint16_t maxMediaPort = DEFAULT_MEDIA_MAX_PORT);
-    ~FtlServer() = default;
+    virtual ~FtlServer() = default;
 
     /* Public functions */
     /**
      * @brief Starts listening for FTL connections on a new thread.
      */
-    void StartAsync();
+    virtual void StartAsync();
 
     /**
      * @brief Stops listening for FTL connections.
      */
-    void Stop();
+    virtual void Stop();
 
-    /**
-     * @brief Called by FtlControlConnection when the control connection has stopped.
-     */
-    void ControlConnectionStopped(FtlControlConnection* connection);
-
-    /**
-     * @brief Called by FtlControlConnection when it wants an HMAC key for a channel
-     */
-    void ControlConnectionRequestedHmacKey(FtlControlConnection* connection,
-        ftl_channel_id_t channelId);
-
-    /**
-     * @brief Called by FtlControlConnection when it needs a media port assigned
-     */
-    void ControlConnectionRequestedMediaPort(FtlControlConnection* connection,
-        ftl_channel_id_t channelId, MediaMetadata mediaMetadata, in_addr targetAddr);
+    /* FtlControlConnectionManager implementation */
+    virtual void ControlConnectionStopped(FtlControlConnection* connection) override;
+    virtual void ControlConnectionRequestedHmacKey(FtlControlConnection* connection,
+        ftl_channel_id_t channelId) override;
+    virtual void ControlConnectionRequestedMediaPort(FtlControlConnection* connection,
+        ftl_channel_id_t channelId, MediaMetadata mediaMetadata, in_addr targetAddr) override;
 
     /**
      * @brief Stops the stream with the specified channel ID and stream ID.
      * This will not fire the StreamEnded callback.
      */
-    void StopStream(ftl_channel_id_t channelId, ftl_stream_id_t streamId);
+    virtual void StopStream(ftl_channel_id_t channelId, ftl_stream_id_t streamId);
 
     /**
      * @brief Retrieves stats for all active streams
      */
-    std::list<std::pair<std::pair<ftl_channel_id_t, ftl_stream_id_t>,
+    virtual std::list<std::pair<std::pair<ftl_channel_id_t, ftl_stream_id_t>,
         std::pair<FtlStream::FtlStreamStats, FtlStream::FtlKeyframe>>>
         GetAllStatsAndKeyframes();
 
     /**
      * @brief Retrieves stats for the given stream
      */
-    Result<FtlStream::FtlStreamStats> GetStats(ftl_channel_id_t channelId,
+    virtual Result<FtlStream::FtlStreamStats> GetStats(ftl_channel_id_t channelId,
         ftl_stream_id_t streamId);
 
 private:

--- a/src/FtlStream.cpp
+++ b/src/FtlStream.cpp
@@ -9,7 +9,6 @@
 
 #include "ConnectionTransports/ConnectionTransport.h"
 #include "FtlControlConnection.h"
-#include "JanusSession.h"
 #include "Utilities/Rtp.h"
 
 #include <algorithm>

--- a/src/Utilities/Util.h
+++ b/src/Utilities/Util.h
@@ -60,7 +60,7 @@ public:
         std::uniform_int_distribution<uint8_t> uniformDistribution(0x00, 0xFF);
         for (unsigned int i = 0; i < size; ++i)
         {
-            payload[i] = std::byte{ uniformDistribution(randomEngine) };
+            payload.emplace_back(std::byte{ uniformDistribution(randomEngine) });
         }
         return payload;
     }

--- a/test/mocks/MockConnectionTransport.h
+++ b/test/mocks/MockConnectionTransport.h
@@ -29,6 +29,16 @@ public:
         }
     }
 
+    void InjectReceivedBytes(const std::string& str)
+    {
+        if (onBytesReceived)
+        {
+            onBytesReceived(std::vector<std::byte>(
+                reinterpret_cast<const std::byte*>(str.data()),
+                reinterpret_cast<const std::byte*>(str.data()) + str.size()));
+        }
+    }
+
     void SetOnWrite(std::function<void(const std::vector<std::byte>&)> onWrite)
     {
         this->onWrite = onWrite;

--- a/test/mocks/MockConnectionTransport.h
+++ b/test/mocks/MockConnectionTransport.h
@@ -12,6 +12,14 @@
 class MockConnectionTransport : public ConnectionTransport
 {
 public:
+    MockConnectionTransport()
+    { }
+
+    MockConnectionTransport(std::function<void(const std::vector<std::byte>&)> onWrite,
+        std::function<void(const std::vector<std::byte>&)> onBytesReceived) : 
+        onWrite(onWrite), onBytesReceived(onBytesReceived)
+    { }
+
     /* Mock methods */
     void InjectReceivedBytes(const std::vector<std::byte>& bytes)
     {
@@ -19,6 +27,11 @@ public:
         {
             onBytesReceived(bytes);
         }
+    }
+
+    void SetOnWrite(std::function<void(const std::vector<std::byte>&)> onWrite)
+    {
+        this->onWrite = onWrite;
     }
 
     /* ConnectionTransport Implementation */
@@ -38,19 +51,18 @@ public:
     }
 
     void Stop(bool noBlock = false) override
-    {
-
-    }
+    { }
 
     void Write(const std::vector<std::byte>& bytes) override
     {
-
+        if (onWrite)
+        {
+            onWrite(bytes);
+        }
     }
 
     void SetOnConnectionClosed(std::function<void(void)> onConnectionClosed) override
-    {
-
-    }
+    { }
 
     void SetOnBytesReceived(
         std::function<void(const std::vector<std::byte>&)> onBytesReceived) override
@@ -59,5 +71,6 @@ public:
     }
 
 private:
+    std::function<void(const std::vector<std::byte>&)> onWrite;
     std::function<void(const std::vector<std::byte>&)> onBytesReceived;
 };

--- a/test/mocks/MockConnectionTransport.h
+++ b/test/mocks/MockConnectionTransport.h
@@ -12,6 +12,15 @@
 class MockConnectionTransport : public ConnectionTransport
 {
 public:
+    /* Mock methods */
+    void InjectReceivedBytes(const std::vector<std::byte>& bytes)
+    {
+        if (onBytesReceived)
+        {
+            onBytesReceived(bytes);
+        }
+    }
+
     /* ConnectionTransport Implementation */
     std::optional<sockaddr_in> GetAddr() override
     {
@@ -46,6 +55,9 @@ public:
     void SetOnBytesReceived(
         std::function<void(const std::vector<std::byte>&)> onBytesReceived) override
     {
-
+        this->onBytesReceived = onBytesReceived;
     }
+
+private:
+    std::function<void(const std::vector<std::byte>&)> onBytesReceived;
 };

--- a/test/mocks/MockConnectionTransport.h
+++ b/test/mocks/MockConnectionTransport.h
@@ -1,0 +1,51 @@
+/**
+ * @file MockConnectionTransport.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2021-03-18
+ * @copyright Copyright (c) 2021 Hayden McAfee
+ */
+
+#pragma once
+
+#include "../../src/ConnectionTransports/ConnectionTransport.h"
+
+class MockConnectionTransport : public ConnectionTransport
+{
+public:
+    /* ConnectionTransport Implementation */
+    std::optional<sockaddr_in> GetAddr() override
+    {
+        return sockaddr_in { 0 };
+    }
+
+    std::optional<sockaddr_in6> GetAddr6() override
+    {
+        return sockaddr_in6 { 0 };
+    }
+
+    Result<void> StartAsync() override
+    {
+        return Result<void>::Success();
+    }
+
+    void Stop(bool noBlock = false) override
+    {
+
+    }
+
+    void Write(const std::vector<std::byte>& bytes) override
+    {
+
+    }
+
+    void SetOnConnectionClosed(std::function<void(void)> onConnectionClosed) override
+    {
+
+    }
+
+    void SetOnBytesReceived(
+        std::function<void(const std::vector<std::byte>&)> onBytesReceived) override
+    {
+
+    }
+};

--- a/test/mocks/MockFtlControlConnectionManager.h
+++ b/test/mocks/MockFtlControlConnectionManager.h
@@ -9,28 +9,50 @@
 
 #include "../../src/FtlControlConnectionManager.h"
 
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+
 class MockFtlControlConnectionManager : public FtlControlConnectionManager
 {
 public:
     /* Constructor/Destructor */
-    MockFtlControlConnectionManager()
+    MockFtlControlConnectionManager(
+        std::function<void(FtlControlConnection*)> onControlConnectionStopped,
+        std::function<void(FtlControlConnection*, ftl_channel_id_t)> 
+            onControlConnectionRequestedHmacKey,
+        std::function<void(FtlControlConnection* connection, ftl_channel_id_t channelId,
+            MediaMetadata mediaMetadata, in_addr targetAddr)> onControlConnectionRequestedMediaPort)
+    :
+        onControlConnectionStopped(onControlConnectionStopped),
+        onControlConnectionRequestedHmacKey(onControlConnectionRequestedHmacKey),
+        onControlConnectionRequestedMediaPort(onControlConnectionRequestedMediaPort)
     { }
 
     /* FtlControlConnectionManager implementation */
     virtual void ControlConnectionStopped(FtlControlConnection* connection)
     {
-
+        onControlConnectionStopped(connection);
     }
 
     virtual void ControlConnectionRequestedHmacKey(FtlControlConnection* connection,
         ftl_channel_id_t channelId)
     {
-
+        onControlConnectionRequestedHmacKey(connection, channelId);
     }
 
     virtual void ControlConnectionRequestedMediaPort(FtlControlConnection* connection,
         ftl_channel_id_t channelId, MediaMetadata mediaMetadata, in_addr targetAddr)
     {
-
+        onControlConnectionRequestedMediaPort(connection, channelId, mediaMetadata, targetAddr);
     }
+
+private:
+    /* Private fields */
+    std::function<void(FtlControlConnection*)> onControlConnectionStopped;
+    std::function<void(FtlControlConnection*, ftl_channel_id_t)> 
+        onControlConnectionRequestedHmacKey;
+    std::function<void(FtlControlConnection* connection, ftl_channel_id_t channelId,
+        MediaMetadata mediaMetadata, in_addr targetAddr)> onControlConnectionRequestedMediaPort;
 };

--- a/test/mocks/MockFtlControlConnectionManager.h
+++ b/test/mocks/MockFtlControlConnectionManager.h
@@ -1,0 +1,36 @@
+/**
+ * @file MockFtlServer.h
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2021-03-18
+ * @copyright Copyright (c) 2021 Hayden McAfee
+ */
+
+#pragma once
+
+#include "../../src/FtlControlConnectionManager.h"
+
+class MockFtlControlConnectionManager : public FtlControlConnectionManager
+{
+public:
+    /* Constructor/Destructor */
+    MockFtlControlConnectionManager()
+    { }
+
+    /* FtlControlConnectionManager implementation */
+    virtual void ControlConnectionStopped(FtlControlConnection* connection)
+    {
+
+    }
+
+    virtual void ControlConnectionRequestedHmacKey(FtlControlConnection* connection,
+        ftl_channel_id_t channelId)
+    {
+
+    }
+
+    virtual void ControlConnectionRequestedMediaPort(FtlControlConnection* connection,
+        ftl_channel_id_t channelId, MediaMetadata mediaMetadata, in_addr targetAddr)
+    {
+
+    }
+};

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -5,7 +5,11 @@
  * @copyright Copyright (c) 2020 Hayden McAfee
  */
 
-#define CATCH_CONFIG_RUNNER // This tells Catch that we'll be providing the main entrypoint
+// Some Catch2 defines required for PCH support
+// https://github.com/catchorg/Catch2/blob/v2.x/docs/ci-and-misc.md#precompiled-headers-pchs
+#undef TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
+#define CATCH_CONFIG_IMPL_ONLY
+#define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
 
 int main(int argc, char* argv[])

--- a/test/unit/FtlControlConnectionUnitTests.cpp
+++ b/test/unit/FtlControlConnectionUnitTests.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <memory>
+#include <openssl/hmac.h>
 #include <optional>
 #include <unordered_map>
 #include <utility>
@@ -85,6 +86,11 @@ public:
         return controlConnections.at(connection);
     }
 
+protected:
+    // Protected fields
+    static constexpr int FTL_PROTOCOL_VERSION_MAJOR = 0;
+    static constexpr int FTL_PROTOCOL_VERSION_MINOR = 9;
+
 private:
     // Private fields
     std::unique_ptr<MockFtlControlConnectionManager> connectionManager;
@@ -122,6 +128,24 @@ private:
 TEST_CASE_METHOD(FtlControlConnectionUnitTestsFixture,
     "FtlControlConnection can negotiate valid control connections")
 {
+    uint16_t mediaPort = 9876;
+    ftl_channel_id_t channelId = 1234;
+    MediaMetadata metadata
+    {
+        .VendorName = "TEST",
+        .VendorVersion = "0.0.0",
+        .HasVideo = true,
+        .HasAudio = true,
+        .VideoCodec = VideoCodecKind::H264,
+        .AudioCodec = AudioCodecKind::Opus,
+        .VideoWidth = 1920,
+        .VideoHeight = 1080,
+        .VideoSsrc = 1235,
+        .AudioSsrc = 1234,
+        .VideoPayloadType = 96,
+        .AudioPayloadType = 97,
+    };
+
     // Come up with a stream HMAC key
     std::vector<std::byte> hmacKey = 
     {
@@ -147,12 +171,7 @@ TEST_CASE_METHOD(FtlControlConnectionUnitTestsFixture,
         });
 
     // Start our FTL handshake
-    std::vector<std::byte> hmacMessage = 
-    {
-        std::byte('H'),  std::byte('M'),  std::byte('A'),  std::byte('C'),
-        std::byte('\r'), std::byte('\n'), std::byte('\r'), std::byte('\n'),
-    };
-    mockTransportPtr->InjectReceivedBytes(hmacMessage);
+    mockTransportPtr->InjectReceivedBytes("HMAC\r\n\r\n");
     // We receive a response payload immediately on the same thread via
     // MockConnectionTransport::Write
     REQUIRE(lastPayloadReceived.size() > 4);
@@ -162,7 +181,103 @@ TEST_CASE_METHOD(FtlControlConnectionUnitTestsFixture,
     std::string hmacPayloadString(reinterpret_cast<char*>((lastPayloadReceived.data()) + 4),
         (reinterpret_cast<char*>(lastPayloadReceived.data()) + lastPayloadReceived.size() - 1));
     std::vector<std::byte> hmacPayloadBytes = Util::HexStringToByteArray(hmacPayloadString);
+    lastPayloadReceived.clear();
 
     // Generate our HMAC response
-    
+    std::byte hmacBuffer[512];
+    uint32_t hmacBufferLength;
+    HMAC(
+        EVP_sha512(),
+        hmacKey.data(),
+        hmacKey.size(),
+        reinterpret_cast<const unsigned char*>(hmacPayloadBytes.data()),
+        hmacPayloadBytes.size(),
+        reinterpret_cast<unsigned char*>(hmacBuffer),
+        &hmacBufferLength);
+    std::string hmacBufferString = Util::ByteArrayToHexString(&hmacBuffer[0], hmacBufferLength);
+    std::string connectMessage = fmt::format("CONNECT {} ${}\r\n\r\n", channelId, hmacBufferString);
+    mockTransportPtr->InjectReceivedBytes(connectMessage);
+
+    // Verify that the control connection has requested an HMAC key for this channel
+    std::optional<FtlControlConnectionState> controlState = 
+        GetFtlControlConnectionState(controlConnection.get());
+    REQUIRE(controlState.has_value());
+    REQUIRE(controlState.value().HmacKeyRequest.has_value());
+    REQUIRE(controlState.value().HmacKeyRequest.value().ChannelId == channelId);
+
+    // Provide the HMAC key to the control connection
+    controlConnection->ProvideHmacKey(hmacKey);
+
+    // Verify we received a response
+    REQUIRE(lastPayloadReceived.size() == 4);
+    responseCode = std::string(reinterpret_cast<char*>(lastPayloadReceived.data()),
+        (reinterpret_cast<char*>(lastPayloadReceived.data()) + 3));
+    REQUIRE(responseCode == "200");
+    lastPayloadReceived.clear();
+
+    // Send metadata
+    mockTransportPtr->InjectReceivedBytes(fmt::format(
+        "ProtocolVersion: {}.{}\r\n\r\n",
+        FTL_PROTOCOL_VERSION_MAJOR,
+        FTL_PROTOCOL_VERSION_MINOR));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("VendorName: {}\r\n\r\n", metadata.VendorName));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("VendorVersion: {}\r\n\r\n", metadata.VendorVersion));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("Video: {}\r\n\r\n", metadata.HasVideo ? "true" : "false"));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("VideoCodec: {}\r\n\r\n",
+            SupportedVideoCodecs::VideoCodecString(metadata.VideoCodec)));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("VideoHeight: {}\r\n\r\n", metadata.VideoHeight));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("VideoWidth: {}\r\n\r\n", metadata.VideoWidth));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("VideoPayloadType: {}\r\n\r\n", metadata.VideoPayloadType));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("VideoIngestSSRC: {}\r\n\r\n", metadata.VideoSsrc));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("Audio: {}\r\n\r\n", metadata.HasAudio ? "true" : "false"));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("AudioCodec: {}\r\n\r\n",
+            SupportedAudioCodecs::AudioCodecString(metadata.AudioCodec)));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("AudioPayloadType: {}\r\n\r\n", metadata.AudioPayloadType));
+    mockTransportPtr->InjectReceivedBytes(
+        fmt::format("AudioIngestSSRC: {}\r\n\r\n", metadata.AudioSsrc));
+
+    // Connect
+    mockTransportPtr->InjectReceivedBytes(".\r\n\r\n");
+
+    // Verify that a media port has been requested and metadata has been reported correctly
+    controlState = GetFtlControlConnectionState(controlConnection.get());
+    REQUIRE(controlState.has_value());
+    REQUIRE(controlState.value().MediaPortRequest.has_value());
+    REQUIRE(controlState.value().MediaPortRequest.value().ChannelId == channelId);
+    MediaMetadata requestMetadata = controlState.value().MediaPortRequest.value().MediaMetadataInfo;
+    REQUIRE(requestMetadata.VendorName == metadata.VendorName);
+    REQUIRE(requestMetadata.VendorVersion == metadata.VendorVersion);
+    REQUIRE(requestMetadata.HasVideo == metadata.HasVideo);
+    REQUIRE(requestMetadata.HasAudio == metadata.HasAudio);
+    REQUIRE(requestMetadata.VideoCodec == metadata.VideoCodec);
+    REQUIRE(requestMetadata.AudioCodec == metadata.AudioCodec);
+    REQUIRE(requestMetadata.VideoWidth == metadata.VideoWidth);
+    REQUIRE(requestMetadata.VideoHeight == metadata.VideoHeight);
+    REQUIRE(requestMetadata.VideoSsrc == metadata.VideoSsrc);
+    REQUIRE(requestMetadata.AudioSsrc == metadata.AudioSsrc);
+    REQUIRE(requestMetadata.VideoPayloadType == metadata.VideoPayloadType);
+    REQUIRE(requestMetadata.AudioPayloadType == metadata.AudioPayloadType);
+
+    // Assign a media port
+    controlConnection->StartMediaPort(mediaPort);
+
+    // Verify we received a response
+    REQUIRE(lastPayloadReceived.size() > 0);
+    std::string mediaPortMessage = std::string(
+        reinterpret_cast<char*>(lastPayloadReceived.data()),
+        (reinterpret_cast<char*>(lastPayloadReceived.data()) + lastPayloadReceived.size()));
+    std::string expectedMediaPortMessage = fmt::format("{} hi. Use UDP port {}\n", 200, mediaPort);
+    REQUIRE(mediaPortMessage == expectedMediaPortMessage);
+    lastPayloadReceived.clear();
 }

--- a/test/unit/FtlControlConnectionUnitTests.cpp
+++ b/test/unit/FtlControlConnectionUnitTests.cpp
@@ -6,22 +6,132 @@
  */
 
 #include <memory>
+#include <optional>
+#include <unordered_map>
+#include <utility>
 
 #include "../../src/FtlControlConnection.h"
 #include "../mocks/MockConnectionTransport.h"
 #include "../mocks/MockFtlControlConnectionManager.h"
 
-TEST_CASE("FtlControlConnection can negotiate valid control connections")
+/**
+ * @brief Test fixture to expose some convenient helpers
+ */
+class FtlControlConnectionUnitTestsFixture
 {
-    // Fire up a MockFtlControlConnectionManager for the FtlControlConnection to report to
-    auto connectionManager = std::make_unique<MockFtlControlConnectionManager>();
+public:
+    // Public types
+    struct FtlControlConnectionHmacKeyRequest
+    {
+        ftl_channel_id_t ChannelId;
+    };
+    struct FtlControlConnectionMediaPortRequest
+    {
+        ftl_channel_id_t ChannelId;
+        MediaMetadata MediaMetadataInfo;
+        in_addr TargetAddr;
+    };
+    struct FtlControlConnectionState
+    {
+        bool HasStopped{ false };
+        std::optional<FtlControlConnectionHmacKeyRequest> HmacKeyRequest;
+        std::optional<FtlControlConnectionMediaPortRequest> MediaPortRequest;
+    };
 
-    // Fire up a mock connection transport that we'll use to inject fake socket data
-    auto mockTransport = std::make_unique<MockConnectionTransport>();
-    // Keep track of the raw pointer, since we'll pass unique ownership to the control connection
-    // auto mockTransportPtr = mockTransport.get();
+    // Constructor
+    FtlControlConnectionUnitTestsFixture() :
+        connectionManager(std::make_unique<MockFtlControlConnectionManager>(
+            std::bind(
+                &FtlControlConnectionUnitTestsFixture::handleControlConnectionStopped,
+                this, std::placeholders::_1),
+            std::bind(
+                &FtlControlConnectionUnitTestsFixture::handleControlConnectionRequestedHmacKey,
+                this, std::placeholders::_1, std::placeholders::_2),
+            std::bind(
+                &FtlControlConnectionUnitTestsFixture::handleControlConnectionRequestedMediaPort,
+                this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+                std::placeholders::_4)))
+    { }
 
-    // Spin up our FtlControlConnection
-    auto controlConnection = std::make_unique<FtlControlConnection>(connectionManager.get(),
-        std::move(mockTransport));
+    // Public functions
+    /**
+     * @brief Creates a MockConnectionTransport and provides it as the transport for a new
+     * FtlControlConnection instance.
+     */
+    std::pair<std::unique_ptr<FtlControlConnection>, MockConnectionTransport*>
+        ConnectMockControlConnection()
+    {
+        auto mockTransport = std::make_unique<MockConnectionTransport>();
+        MockConnectionTransport* mockTransportPtr = mockTransport.get();
+        auto controlConnection = std::make_unique<FtlControlConnection>(connectionManager.get(),
+            std::move(mockTransport));
+
+        return { std::move(controlConnection), mockTransportPtr };
+    }
+
+    /**
+     * @brief Retrieves the current state (if it exists) of the FtlControlConnection as reported
+     * by the FtlControlConnectionManager
+     */
+    std::optional<FtlControlConnectionState> GetFtlControlConnectionState(
+        FtlControlConnection* connection)
+    {
+        if (controlConnections.count(connection) <= 0)
+        {
+            return std::nullopt;
+        }
+
+        return controlConnections.at(connection);
+    }
+
+private:
+    // Private fields
+    std::unique_ptr<MockFtlControlConnectionManager> connectionManager;
+    std::unordered_map<FtlControlConnection*, FtlControlConnectionState> controlConnections;
+
+    // Private functions
+    void handleControlConnectionStopped(FtlControlConnection* connection)
+    {
+        controlConnections[connection].HasStopped = true;
+    }
+
+    void handleControlConnectionRequestedHmacKey(FtlControlConnection* connection,
+        ftl_channel_id_t channelId)
+    {
+        controlConnections[connection].HmacKeyRequest =
+            FtlControlConnectionHmacKeyRequest {
+                .ChannelId = channelId
+            };
+    }
+
+    void handleControlConnectionRequestedMediaPort(FtlControlConnection* connection,
+        ftl_channel_id_t channelId, MediaMetadata mediaMetadata, in_addr targetAddr)
+    {
+        controlConnections[connection].MediaPortRequest =
+            FtlControlConnectionMediaPortRequest {
+                .ChannelId = channelId,
+                .MediaMetadataInfo = mediaMetadata,
+                .TargetAddr = targetAddr
+            };
+    }
+};
+
+TEST_CASE_METHOD(FtlControlConnectionUnitTestsFixture,
+    "FtlControlConnection can negotiate valid control connections")
+{
+    auto [controlConnection, mockTransportPtr] = ConnectMockControlConnection();
+
+    // Expect control connection to not yet have reported anything to the
+    // FtlControlConnectionManager
+    REQUIRE(GetFtlControlConnectionState(controlConnection.get()) == std::nullopt);
+
+    // Start our FTL handshake
+    std::vector<std::byte> hmacMessage = 
+        {
+            std::byte('H'),  std::byte('M'),  std::byte('A'),  std::byte('C'),
+            std::byte('\r'), std::byte('\n'), std::byte('\r'), std::byte('\n'),
+        };
+    mockTransportPtr->InjectReceivedBytes(hmacMessage);
+    // TODO: Mock transport needs to receive HMAC payload here
+    // ...
 }

--- a/test/unit/FtlControlConnectionUnitTests.cpp
+++ b/test/unit/FtlControlConnectionUnitTests.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file FtlControlConnectionUnitTests.cpp
+ * @author Hayden McAfee (hayden@outlook.com)
+ * @date 2021-03-18
+ * @copyright Copyright (c) 2021 Hayden McAfee
+ */
+
+#include <memory>
+
+#include "../../src/FtlControlConnection.h"
+#include "../mocks/MockConnectionTransport.h"
+#include "../mocks/MockFtlControlConnectionManager.h"
+
+TEST_CASE("FtlControlConnection can negotiate valid control connections")
+{
+    // Fire up a MockFtlControlConnectionManager for the FtlControlConnection to report to
+    auto connectionManager = std::make_unique<MockFtlControlConnectionManager>();
+
+    // Fire up a mock connection transport that we'll use to inject fake socket data
+    auto mockTransport = std::make_unique<MockConnectionTransport>();
+    // Keep track of the raw pointer, since we'll pass unique ownership to the control connection
+    // auto mockTransportPtr = mockTransport.get();
+
+    // Spin up our FtlControlConnection
+    auto controlConnection = std::make_unique<FtlControlConnection>(connectionManager.get(),
+        std::move(mockTransport));
+}


### PR DESCRIPTION
Introduces the following changes:

- `FtlControlConnectionManager` interface introduced to abstract callbacks from `FtlControlConnection` (such as `ControlConnectionStopped`, `ControlConnectionRequestedHmacKey`, etc. `FtlServer` implements this interface.
- `MockFtlControlConnectionManager` introduced to facilitate unit testing of `FtlControlConnection`
- `MockConnectionTransport` introduced to facilitate unit testing of any class that uses `ConnectionTransport` classes.
- Various PCH/build changes to improve build of test binary
- `FtlControlConnectionUnitTests.cpp` added with a simple text fixture and test case verifying the FTL connection handshake is processed correctly by `FtlControlConnection`
- GitHub action added to run test binary for validation.