### PR TITLE
🏓 Ping handling for FTL media streams

### DIFF
--- a/src/FtlStream.cpp
+++ b/src/FtlStream.cpp
@@ -587,11 +587,8 @@ void FtlStream::processAudioVideoRtpPacket(const std::vector<std::byte>& rtpPack
 
 void FtlStream::handlePing(const std::vector<std::byte>& rtpPacket)
 {
-    // These pings are useless - FTL tries to determine 'ping' by having a timestamp
-    // sent across and compared against the remote's clock. This assumes that there is
-    // no time difference between the client and server, which is practically never true.
-
-    // We'll just ignore these pings, since they wouldn't give us any useful information anyway.
+    // FTL client is trying to measure round trip time (RTT), pong back the same packet
+    mediaTransport->Write(rtpPacket);
 }
 
 void FtlStream::handleSenderReport(const std::vector<std::byte>& rtpPacket)


### PR DESCRIPTION
This ping is not expected to be used by the server, it is meant to be ponged back to the client as part of measuring RTT.

Now it's true the client only uses this right now to do a bandwidth test it then ignores, but it does log the bandwidth so it'd be nice for debugging to have the numbers be accurate (right now the client defaults to a two second RTT because it never gets a pong to measure)

See https://github.com/Glimesh/ftl-sdk/blob/5912733506c066684aebd43f3e0b94cf51ca98c1/libftl/media.c#L1165-L1174