### PR TITLE
🔐 Add stopping lock to FtlClient

### DIFF
--- a/src/FtlClient.h
+++ b/src/FtlClient.h
@@ -97,9 +97,10 @@ private:
     const std::string targetHostname;
     const ftl_channel_id_t channelId;
     const std::vector<std::byte> streamKey;
-    std::atomic<bool> isStopping { false }; // Set once close has been called on the sockets and we
-                                            // are waiting for the connection thread to notice.
-    std::atomic<bool> isStopped { false };  // Set just before the connection thread exits.
+    bool isStopping = false; // Set once close has been called on the sockets and we
+                             // are waiting for the connection thread to notice.
+    bool isStopped = false;  // Set just before the connection thread exits.
+    std::mutex stoppingMutex;
     int controlSocketHandle = 0;
     std::promise<void> connectionThreadEndedPromise;
     std::future<void> connectionThreadEndedFuture = connectionThreadEndedPromise.get_future();


### PR DESCRIPTION
We noticed last night that there is a race condition in FtlClient that can lead to a double close of a socket, for now protecting with a mutex following an identical pattern to what NetworkSocketConnectionTransport does.

Verified locally by refreshing a single viewer several times to stop/create new edge ftl clients.

Might help with #115