### PR TITLE
🔊 Ask receiver to play stereo audio

### DIFF
--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -839,7 +839,7 @@ std::string JanusFtl::generateSdpOffer(const ActiveSession& session, const Janus
             "m=audio 1 RTP/SAVPF " << audioPayloadType << "\r\n" <<
             "c=IN IP4 1.1.1.1\r\n" <<
             "a=rtpmap:" << audioPayloadType << " " << audioCodec << "/48000/2\r\n" <<
-            "a=fmtp:" << audioPayloadType << " useinbandfec=1;sprop-stereo=1;\r\n" <<
+            "a=fmtp:" << audioPayloadType << " sprop-stereo=1;\r\n" <<
             "a=sendonly\r\n" <<
             "a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid\r\n";
     }

--- a/src/JanusFtl.cpp
+++ b/src/JanusFtl.cpp
@@ -839,6 +839,7 @@ std::string JanusFtl::generateSdpOffer(const ActiveSession& session, const Janus
             "m=audio 1 RTP/SAVPF " << audioPayloadType << "\r\n" <<
             "c=IN IP4 1.1.1.1\r\n" <<
             "a=rtpmap:" << audioPayloadType << " " << audioCodec << "/48000/2\r\n" <<
+            "a=fmtp:" << audioPayloadType << " useinbandfec=1;sprop-stereo=1;\r\n" <<
             "a=sendonly\r\n" <<
             "a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid\r\n";
     }


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc7587#section-6.1 if the sender does not specify `sprop-stereo=1` the receiver may default to downmixing stereo sources to mono.

Firefox does this: https://bugzilla.mozilla.org/show_bug.cgi?id=1524145